### PR TITLE
feat(visualize): add Markmap engine routing for mind map diagrams

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -85,7 +85,8 @@
 			"!**/.claude",
 			"!**/website",
 			"!!**/*@*@@@*",
-			"!**/PROJECT_INDEX.json"
+			"!**/PROJECT_INDEX.json",
+			"!**/.worktrees"
 		]
 	}
 }

--- a/docs/plans/2026-03-01-feat-mindmap-engine-routing-export-parity-plan.md
+++ b/docs/plans/2026-03-01-feat-mindmap-engine-routing-export-parity-plan.md
@@ -1,0 +1,444 @@
+---
+created: 2026-03-01
+updated: 2026-03-02
+title: "Mind Map Engine Routing with Export Parity and Theme Alignment"
+type: plan
+tags: [cortex, visualize, mindmap, markmap, mermaid, export, theming]
+project: cortex-engineering
+status: completed
+origin: docs/brainstorms/2026-03-01-mindmap-engine-routing-brainstorm.md
+---
+
+> Origin: docs/brainstorms/2026-03-01-mindmap-engine-routing-brainstorm.md
+> Planning basis: Local repo research + existing in-repo mind map research + targeted vendor-doc verification (Markmap docs, Mermaid docs, npm package state)
+
+# feat: Mind Map Engine Routing with Export Parity and Theme Alignment
+
+## Enhancement Summary
+
+**Deepened on:** 2026-03-02
+**Review agents used:** code-simplicity-reviewer, architecture-strategist, pattern-recognition-specialist, spec-flow-analyzer, skill-authoring specialist, markmap-cli researcher
+
+### Key Improvements
+
+1. **Export pipeline identified as #1 risk** -- markmap-cli outputs HTML only. SVG/PDF requires custom Puppeteer scripting. No maintained wrappers exist. Plan restructured to spike this first before any skill documentation work.
+2. **Plan complexity reduced ~60%** -- 6 phases collapsed to 3 (spike, implement, validate). Config precedence chain simplified -- no config system exists yet, so routing is auto-default + user override at confirmation prompt.
+3. **Source file naming collision resolved** -- `mindmap.md` conflicts with Cortex `.md` convention. Decision: use `mindmap.mmd` with `engine:` frontmatter field to distinguish rendering engine.
+4. **Skill structure decision: start lean** -- Markmap knowledge lives in `visualize/references/engine-routing.md` initially (YAGNI). Promote to separate `markmap-diagrams` companion skill when craft knowledge exceeds ~100 lines.
+5. **New frontmatter field: `engine:`** -- added to diagram doc type for reliable re-render detection. Optional, defaults to `mermaid`.
+
+### New Considerations Discovered
+
+- Markmap's JSON styling options have no `fontFamily`, `fontSize`, or `backgroundColor` -- font styling requires `extraCss` injection
+- Sketch and Blueprint presets are Mermaid-specific (handDrawn look, ELK layout). Markmap gets one style only (Classic colors via Okabe-Ito palette). Preset selection hidden for Markmap with a one-line note.
+- Engine switch on existing directory leaves orphaned source file (different syntax). Collision handling must account for cross-engine overwrites.
+- `markmap-cli` version 0.18.12 is current. All markmap packages are version-locked.
+- The fenced code block in index.md should use ````markmap` language tag (enables Obsidian's markmap plugin for inline preview)
+
+### Export Pipeline: Proven Approach
+
+Markmap is "HTML-first" by design -- the CLI generates an HTML page containing the SVG (rendered by markmap-view in the browser). Native SVG/PDF export isn't a first-class feature. The reliable approach is to **productize the Puppeteer extraction step**:
+
+1. `markmap-cli` -> HTML (with embedded SVG rendered by D3/markmap-view)
+2. Puppeteer opens the HTML -> extracts the `<svg>` element -> saves as `.svg`
+3. Puppeteer prints the page -> saves as `.pdf`
+
+This works because markmap-view renders an actual SVG in-browser, so Puppeteer can "steal" it. We already have Puppeteer as a dependency (mermaid-cli uses it). The script is ~15 lines and the approach is well-understood in the community.
+
+**To productize:** Pin the Chromium version (already handled by mermaid-cli's Puppeteer), add the export script to the plugin, and add a small regression check that output isn't blank.
+
+## Overview
+
+Add first-class multi-engine mind map support to the visualize workflow by auto-routing mind map requests to Markmap by default while preserving Mermaid for non-mind-map diagram types. Keep a single user-facing experience with mandatory export parity (`SVG` + `PDF` + source artifacts), and align mind map styling with existing design-system and diagram theme conventions.
+
+This plan directly carries forward brainstorm decisions (see brainstorm: docs/brainstorms/2026-03-01-mindmap-engine-routing-brainstorm.md): hybrid routing, configurable engine selection, export parity, optional Obsidian benefits, and theme consistency.
+
+## Problem Statement / Motivation
+
+Current mind map output quality is constrained by Mermaid mind map limitations, which produces lower visual quality than purpose-built mind map renderers. At the same time, users should not have to care which engine was used, and should not lose existing print/export workflows.
+
+We need to improve mind map quality without introducing lock-in or cognitive overhead:
+- Better defaults for mind map visuals.
+- Explicit engine choice for advanced users.
+- Same export contract and paths regardless of engine.
+
+## Research Consolidation
+
+### Repository Findings
+- Visualize workflow currently centers on Mermaid generation and `mmdc` export in the visualize skill: `plugins/cortex-engineering/skills/visualize/SKILL.md`.
+- Mermaid-diagrams skill codifies print-safe presets and export constraints: `plugins/cortex-engineering/skills/mermaid-diagrams/SKILL.md`.
+- Design-system skill defines shared spacing/color/contrast tokens that should inform mind map theming: `plugins/cortex-engineering/skills/design-system/SKILL.md`.
+
+### Institutional Learnings
+- `docs/solutions/` is not present in this repository, so no institutional solution documents were available to carry forward.
+
+### Existing Internal Research
+- `docs/research/2026-02-28-mind-map-rendering-tools.md` already establishes:
+  - Markmap is preferred for mind map visual quality.
+  - Mermaid remains strong for non-mind-map diagrams.
+  - Markmap export requires a dedicated pipeline for SVG/PDF parity.
+
+### Targeted External Verification (2026-03-01)
+- Markmap docs confirm:
+  - `markmap-cli` produces HTML output only (`--output` HTML), so SVG/PDF parity requires Puppeteer.
+  - JSON/frontmatter options support style controls (`color`, spacing, line width) usable for design-system alignment.
+  - No `fontFamily`, `fontSize`, or `backgroundColor` in JSON options -- font styling requires `extraCss`.
+- npm package metadata confirms active Markmap ecosystem releases (`markmap-cli` 0.18.12, all packages version-locked).
+- Mermaid docs still mark `mindmap` as experimental, reinforcing the default routing decision to Markmap for mind-map quality.
+
+### Deepen Pass Research (2026-03-02)
+
+**Markmap CLI verified capabilities:**
+- Output: HTML only (interactive page with D3.js + markmap-view)
+- No built-in SVG or PDF export
+- CLI invocation: `bunx markmap-cli --no-open --no-toolbar --offline -o mindmap.html input.md`
+- JSON options: `color`, `colorFreezeLevel`, `spacingHorizontal` (default 80), `spacingVertical` (default 5), `maxWidth`, `lineWidth`, `initialExpandLevel`
+- No maintained SVG/PDF wrappers exist. `md2mm-svg` (3 commits, 1 star) is abandoned.
+- SVG extraction requires: open HTML in Puppeteer, query the SVG element from DOM, serialize to file
+- PDF export requires: open HTML in Puppeteer, `page.pdf()` with print settings
+
+## Proposed Solution
+
+Implement a hybrid engine-routing model for visualize:
+
+1. **Auto-routing**
+- Detect `mindmap` diagram intent and default engine to Markmap.
+- Keep Mermaid default for all non-mind-map diagram types.
+- Preserve user override at the step 2 confirmation prompt.
+
+2. **Engine selection (simplified)**
+- Auto-default: Markmap for mind maps, Mermaid for everything else.
+- User override: option 5 in the step 2 confirmation prompt (mind maps only).
+- No persistent config until the unified config system ships. When it does, add `mindmap_engine: markmap | mermaid` to `config.yaml`.
+
+3. **Unified output contract (mandatory parity)**
+- Normalize output artifacts across engines:
+  - Source file: `mindmap.mmd` (Markmap source is markdown, but `.mmd` maintains the "diagram source" convention; `engine:` frontmatter field distinguishes the renderer)
+  - `mindmap.svg`
+  - `mindmap.pdf`
+  - `index.md` entry with `## Mind Map` section heading
+- Users receive identical artifact expectations regardless of engine.
+
+4. **Theme alignment**
+- Markmap gets one style: Classic colors via Okabe-Ito palette from design-system skill.
+- Sketch and Blueprint presets are Mermaid-specific -- not applicable to Markmap. Show one-line note: "Markmap uses Classic colors; hand-drawn/ELK modes are Mermaid-only."
+- Concrete Markmap theme: `color: ['#0072B2', '#009E73', '#E69F00', '#D55E00', '#56B4E9', '#CC79A7', '#F0E442']`
+
+## Alternative Approaches Considered
+
+### A) Full abstraction-first multi-engine platform
+- Rejected for now: more architecture than needed for current scope (YAGNI), slower time-to-value.
+
+### B) Obsidian-first specialized flow
+- Rejected: risks perceived lock-in. Obsidian support is optional and out of scope for this plan.
+
+### C) Hybrid routing with explicit overrides (Chosen)
+- Chosen for fast quality gains + flexibility + low cognitive load.
+- Carries forward exact brainstorm direction (see brainstorm: docs/brainstorms/2026-03-01-mindmap-engine-routing-brainstorm.md).
+
+### D) Separate markmap-diagrams companion skill (Deferred)
+- Architecture strategist recommended creating a parallel skill following the mermaid-diagrams pattern.
+- Skill authoring reviewer recommended YAGNI -- start with `visualize/references/engine-routing.md`.
+- **Decision: start lean.** Create the companion skill when Markmap craft knowledge exceeds ~100 lines or multiple skills need to reference it.
+
+## Technical Approach
+
+### Phase 0: Export Pipeline Spike (MUST DO FIRST)
+
+**Validate the Puppeteer extraction approach before any skill documentation work.**
+
+#### Pipeline
+
+```bash
+# Step 1: Generate HTML with embedded SVG
+bunx markmap-cli --no-open --no-toolbar --offline -o mindmap.html input.md
+
+# Step 2: Extract SVG + print PDF via Puppeteer
+node export-markmap.mjs mindmap.html mindmap
+# Produces: mindmap.svg + mindmap.pdf
+```
+
+#### Export script (`export-markmap.mjs`)
+
+```javascript
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import puppeteer from "puppeteer";
+
+const htmlPath = process.argv[2];              // e.g. mindmap.html
+const outBase  = process.argv[3] || "mindmap"; // e.g. mindmap
+
+const absHtml = "file://" + path.resolve(htmlPath);
+
+const browser = await puppeteer.launch({ headless: "new" });
+const page = await browser.newPage();
+await page.goto(absHtml, { waitUntil: "networkidle0" });
+
+// Grab the rendered SVG
+const svg = await page.$eval("svg", el => el.outerHTML);
+await fs.writeFile(`${outBase}.svg`, svg, "utf8");
+
+// Print to PDF
+await page.pdf({
+  path: `${outBase}.pdf`,
+  format: "A4",
+  landscape: true,
+  printBackground: true,
+  margin: { top: "10mm", right: "10mm", bottom: "10mm", left: "10mm" },
+});
+
+await browser.close();
+```
+
+#### Spike tasks
+
+- [x] Run the pipeline on a sample markdown mind map
+- [x] Validate SVG quality: readable text, correct colors, proper sizing for A4/A3
+- [x] Validate PDF quality: print-ready, correct text colors (no grey-text issue -- markmap renders natively with `printBackground: true`)
+- [x] Test with `--offline` flag (inlines all JS/CSS assets -- required for file:// URLs)
+- [x] Verify Puppeteer reuses mermaid-cli's Chromium (no second download)
+- [x] Document any timing issues (D3 animation completion before SVG extraction)
+
+#### Spike results (2026-03-02)
+
+**Branch:** `spike/markmap-export` | **Files:** `spike/markmap-export/`
+
+| Step | Command | Output | Size |
+|------|---------|--------|------|
+| Markdown -> HTML | `bunx markmap-cli --no-open --no-toolbar --offline -o mindmap.html sample.md` | mindmap.html | 335KB |
+| HTML -> SVG + PDF | `node export-markmap.mjs mindmap.html mindmap` | mindmap.svg, mindmap.pdf | 32KB, 49KB |
+
+**SVG structure:** 51 `<g>` groups, 48 `<path>` elements, 49 `<foreignObject>` elements (markmap uses foreignObject for text, not `<text>` elements). All content from sample.md present and readable.
+
+**PDF quality:** 1-page A4 landscape. All nodes readable, colorful Okabe-Ito branch lines, proper hierarchy. Dark background (markmap default).
+
+**Key findings:**
+1. **`--offline` flag is essential** -- without it, the HTML references CDN URLs that fail with `file://` protocol in Puppeteer
+2. **1-second delay needed** -- markmap uses D3 transitions (requestAnimationFrame). The script waits 1s after `waitForSelector('svg')` to let animations complete
+3. **Puppeteer reuses mermaid-cli's Chromium** -- cached at `~/.cache/puppeteer/chrome`, no second download
+4. **No grey-text issue** -- unlike Mermaid PDF export, markmap's `printBackground: true` renders colors correctly without needing a CSS fix
+5. **Dark background is markmap's default** -- for print, may want to inject `extraCss` to set white background. Not blocking -- dark looks good on screen
+6. **foreignObject rendering** -- markmap uses HTML-in-SVG via foreignObject rather than SVG `<text>`. This means the extracted SVG depends on a browser for full rendering (not a pure SVG). For print-ready output, PDF is the better format
+
+**Spike exit criteria:**
+- SVG + PDF both produce print-quality output: proceed to Phase 1 with full parity.
+- SVG works but PDF quality is poor: proceed with SVG-only Markmap + PDF via Mermaid fallback.
+- Neither works reliably: keep Markmap for interactive HTML, Mermaid for all static exports.
+
+**Script location after spike:** `plugins/cortex-engineering/skills/visualize/references/export-markmap.mjs` -- becomes the basis for export instructions in the skill.
+
+### Phase 1: Implement Routing and Export
+
+After the spike validates the pipeline:
+
+- [x] Create `visualize/references/engine-routing.md` with:
+  - Markmap CLI invocation commands (from spike)
+  - SVG extraction pipeline (from spike)
+  - PDF export pipeline (from spike)
+  - Markmap JSON options for theming (Okabe-Ito colors, spacing)
+  - Fallback matrix (same as Mermaid: SVG+PDF -> SVG only -> source only)
+  - Known issues and workarounds
+- [x] Update `visualize/SKILL.md`:
+  - Step 1: extend re-render shortcut to detect both `.mmd` files with `engine: markmap` metadata
+  - Step 2: add one-liner about mind map auto-routing + option 5 (engine override, mind maps only)
+  - Step 2: add note about Sketch/Blueprint being Mermaid-only for mind maps
+  - Step 4: add Markmap export block referencing `engine-routing.md`
+  - Step 5: document `engine:` field in index.md frontmatter and Export annotation
+  - Step 6: add engine name to success report
+- [x] Update `frontmatter/SKILL.md`:
+  - Add `engine:` field to diagram doc type (optional, defaults to `mermaid`)
+- [x] Update `mermaid-diagrams/SKILL.md`:
+  - Add scope clarification: "Mermaid remains the engine for all non-mind-map diagram types"
+- [x] Create Markmap theme config (JSON or CSS in `visualize/references/`):
+  - Okabe-Ito colors: `['#0072B2', '#009E73', '#E69F00', '#D55E00', '#56B4E9', '#CC79A7', '#F0E442']`
+  - `spacingHorizontal: 48` (design-system `xl`)
+  - `spacingVertical: 16` (design-system `sm`)
+  - `maxWidth: 300`
+
+#### Updated confirmation prompt (step 2, mind maps only)
+
+```
+> "I'll generate a **mind map** for **[Topic]**."
+> Defaults: A4, Markmap engine.
+>
+> 1. Go (use defaults)
+> 2. A3 landscape (wall poster)
+> 3. Change style (Classic only for Markmap)
+> 4. Change diagram type
+> 5. Change engine (currently: Markmap)
+```
+
+Option 5 only appears when the auto-detected diagram type supports multiple engines (currently only mind maps). Follow-up shows:
+
+```
+> 1. Markmap - curved branches, auto-colors, beautiful (default)
+> 2. Mermaid - basic shapes, themed presets (Classic/Sketch/Blueprint)
+```
+
+#### index.md section format for Markmap
+
+```markdown
+## Mind Map
+
+```markmap
+# Topic
+## Branch 1
+### Leaf
+## Branch 2
+```
+
+**Export:** Markmap engine, A4 landscape.
+```
+
+The ````markmap` language tag enables Obsidian's markmap plugin for inline preview.
+
+#### Source file convention
+
+Use `mindmap.mmd` as the source filename (maintains the `.mmd` = diagram source convention). The `engine: markmap` field in index.md frontmatter distinguishes the renderer. The file content is standard markdown with heading-based hierarchy, not Mermaid syntax.
+
+#### Re-render detection (step 1)
+
+When the source is an existing diagram directory:
+1. Read `index.md` frontmatter for `engine:` field
+2. If `engine: markmap`: read `mindmap.mmd` as markdown, use Markmap pipeline
+3. If `engine: mermaid` or absent: read `mindmap.mmd` as Mermaid syntax, use mmdc pipeline
+4. If multiple `.mmd` files: list them and ask which to re-render (existing behavior)
+
+#### Fallback chain
+
+- Markmap: SVG+PDF -> SVG only -> source only. Same structure as Mermaid.
+- `bunx` to `npx` fallback for markmap-cli (same Puppeteer native-module issue may apply).
+- **No cross-engine fallback.** If Markmap fails, do NOT silently fall back to Mermaid mind map. Report the failure and let the user choose. Silent engine switching defeats the quality purpose.
+
+### Phase 2: Validation
+
+- [ ] `auto` + mind map -> Markmap route
+- [ ] explicit Mermaid override + mind map -> Mermaid route
+- [ ] non-mind-map + any -> Mermaid route (engine option not shown)
+- [ ] Markmap path creates source + SVG + PDF
+- [ ] Mermaid mindmap path creates source + SVG + PDF (unchanged)
+- [ ] Re-render with engine metadata correctly routes to prior engine
+- [ ] Existing non-mind-map exports unchanged
+- [ ] Output directory structure and naming compatible
+- [ ] `bun run validate` passes
+
+## System-Wide Impact
+
+- **Interaction graph:**
+  - Visualize command -> diagram type detection -> engine resolution -> engine-specific generation/export -> common artifact persistence.
+- **Error propagation:**
+  - Engine-specific export failures converge into the shared fallback/reporting path. No cross-engine fallback.
+- **State lifecycle risks:**
+  - Partial exports may leave incomplete artifact sets; fallback chain preserves what succeeded.
+  - Engine switch on existing directory leaves orphaned source file if syntax differs.
+- **API surface parity:**
+  - Mind map behavior appears through visualize command and its skill workflow docs; both must stay consistent.
+  - Engine option only appears for diagram types with multiple engines (currently only mind maps).
+
+## Acceptance Criteria
+
+### Functional Requirements
+- [x] Mind map requests auto-route to Markmap by default
+- [x] Users can override engine at step 2 confirmation prompt (option 5)
+- [x] Non-mind-map diagrams continue to default to Mermaid (no engine option shown)
+- [x] Output contract is engine-agnostic: source + SVG + PDF
+
+### Export Parity Requirements
+- [x] Markmap pipeline produces SVG and PDF outputs (validated by spike)
+- [x] Fallback behavior is documented and deterministic
+- [x] Output location and naming conventions are consistent (`mindmap.mmd`, `mindmap.svg`, `mindmap.pdf`)
+
+### UX & Theming Requirements
+- [x] User-facing messaging does not require knowing internal engine details
+- [x] Markmap theming uses Okabe-Ito palette from design-system skill
+- [x] Sketch/Blueprint presets show one-line note for Markmap ("hand-drawn/ELK modes are Mermaid-only")
+
+### Documentation & Schema Requirements
+- [x] `engine:` field added to diagram frontmatter in frontmatter skill
+- [x] `engine-routing.md` reference file created in visualize skill
+- [x] Export annotation in index.md includes engine name
+- [x] Version bump to 0.5.0 (minor -- new capability)
+
+### Quality Gates
+- [x] Export pipeline spike completed and documented
+- [x] `bun run validate` passes
+- [ ] Manual scenario checks cover routing, override, and fallback (Phase 2 -- user testing)
+
+## Dependencies & Risks
+
+### Dependencies
+- Existing visualize/mermaid skill architecture and export conventions.
+- Markmap CLI (0.18.12) for HTML generation.
+- Puppeteer (already a dependency via mermaid-cli) for SVG/PDF extraction.
+- Existing design-system token guidance.
+
+### Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|---|---|---|
+| ~~Markmap SVG/PDF extraction produces poor print quality~~ | ~~High~~ | **RESOLVED by spike** -- PDF renders correctly with `printBackground: true`. SVG uses foreignObject (browser-dependent) but PDF is print-ready. |
+| Puppeteer SVG extraction is fragile (DOM timing, D3 animation) | Medium | Use `--no-open --no-toolbar` flags. Wait for D3 transitions to complete. Document known issues. |
+| `mindmap.mmd` contains markdown, not Mermaid -- confusing | Low | `engine:` frontmatter field is the source of truth. Document clearly. |
+| Config system doesn't exist yet for persistent engine preference | Low | Defer to unified config plan. Use auto-default + prompt override for now. |
+| Markmap has no equivalent of Sketch/Blueprint presets | Low | One style only (Classic colors). Show one-line note for unavailable presets. |
+
+## Implementation Task Checklist
+
+- [x] **Spike:** Validate Markmap SVG/PDF export pipeline with Puppeteer
+- [x] **Spike:** Document exact CLI commands and scripts
+- [x] Update `plugins/cortex-engineering/skills/visualize/SKILL.md` (steps 1, 2, 4, 5, 6)
+- [x] Create `plugins/cortex-engineering/skills/visualize/references/engine-routing.md`
+- [x] Create Markmap theme config file in `visualize/references/`
+- [x] Update `plugins/cortex-engineering/skills/frontmatter/SKILL.md` (add `engine:` field)
+- [x] Update `plugins/cortex-engineering/skills/mermaid-diagrams/SKILL.md` (scope clarification)
+- [x] Bump version to 0.5.0 in `plugins/cortex-engineering/.claude-plugin/plugin.json`
+- [x] Run `bun run validate`
+- [x] Update this plan checkboxes during implementation (`[ ]` -> `[x]`)
+
+## Post-Deploy Monitoring & Validation
+
+No additional operational monitoring required: this change is plugin workflow/config behavior with no production service runtime in this repository.
+
+Validation ownership and window:
+- Owner: feature implementer/reviewer pair.
+- Window: during implementation PR and pre-merge validation run.
+
+## Sources & References
+
+### Origin
+- **Brainstorm document:** [docs/brainstorms/2026-03-01-mindmap-engine-routing-brainstorm.md](/Users/nathanvale/code/side-quest-marketplace/docs/brainstorms/2026-03-01-mindmap-engine-routing-brainstorm.md)
+  - Carried-forward decisions:
+  - Markmap default for mind maps.
+  - Mandatory export parity.
+  - Configurable engine selection.
+
+### Internal References
+- [plugins/cortex-engineering/skills/visualize/SKILL.md](/Users/nathanvale/code/side-quest-marketplace/plugins/cortex-engineering/skills/visualize/SKILL.md)
+- [plugins/cortex-engineering/skills/mermaid-diagrams/SKILL.md](/Users/nathanvale/code/side-quest-marketplace/plugins/cortex-engineering/skills/mermaid-diagrams/SKILL.md)
+- [plugins/cortex-engineering/skills/design-system/SKILL.md](/Users/nathanvale/code/side-quest-marketplace/plugins/cortex-engineering/skills/design-system/SKILL.md)
+- [docs/research/2026-02-28-mind-map-rendering-tools.md](/Users/nathanvale/code/side-quest-marketplace/docs/research/2026-02-28-mind-map-rendering-tools.md)
+
+### External References (Verified 2026-03-02)
+- Markmap docs: https://markmap.js.org/docs/markmap
+- Markmap CLI docs: https://markmap.js.org/docs/packages--markmap-cli
+- Markmap JSON options: https://markmap.js.org/docs/json-options
+- Markmap npm package: https://www.npmjs.com/package/markmap-cli (v0.18.12)
+- Markmap SVG export issue #66: https://github.com/markmap/markmap/issues/66 (open since 2021)
+- Mermaid mindmap docs: https://mermaid.js.org/syntax/mindmap.html (still experimental)
+
+### Alternatives Considered for Export
+
+| Option | Verdict | Why |
+|---|---|---|
+| Markmap + Puppeteer extraction | **Chosen** | Automation + versioned markdown source-of-truth. Puppeteer already a dependency. ~15 line script. |
+| MindNode (Mac GUI) | Rejected | No headless CLI. Click-to-export doesn't fit automated workflows. |
+| XMind (GUI + CLI) | Rejected | Markdown import exists but export is GUI-driven. Not automatable. |
+| Mermaid mindmap only | Rejected | Inferior visual quality is the whole reason for this plan. |
+
+### What Was Cut (from original plan)
+
+- **Obsidian compatibility section** -- explicitly out of scope per brainstorm. Removed to reduce cognitive load.
+- **4-level config precedence chain** -- no config system exists yet. Simplified to auto-default + user override.
+- **Phases 1, 5 (Foundation, Backward Compatibility)** -- no foundation to build, nothing to migrate from. These were architecture vocabulary applied to a markdown file edit.
+- **Validation matrix as separate phase** -- integrated into Phase 2 as a checklist.
+- **Separate markmap-diagrams companion skill** -- deferred until craft knowledge grows. Start with `visualize/references/engine-routing.md`.

--- a/plugins/cortex-engineering/.claude-plugin/plugin.json
+++ b/plugins/cortex-engineering/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
 	"name": "cortex-engineering",
 	"description": "Agent-native knowledge system. Research topics and capture findings as structured markdown documents with YAML frontmatter",
-	"version": "0.4.1",
+	"version": "0.5.0",
 	"author": {
 		"name": "Nathan Vale"
 	},

--- a/plugins/cortex-engineering/skills/frontmatter/SKILL.md
+++ b/plugins/cortex-engineering/skills/frontmatter/SKILL.md
@@ -160,7 +160,7 @@ What this decision means going forward.
 
 ### `diagram`
 
-Diagram docs use `## <Label>` section headings for each diagram type (e.g. `## Flowchart`, `## Mind Map`, `## Entity-Relationship Diagram`). Each section contains the Mermaid source in a fenced code block followed by an `**Export:** <preset> theme, <paper> size.` line. This structure is uniform from the first write, so appending a second diagram type never requires restructuring.
+Diagram docs use `## <Label>` section headings for each diagram type (e.g. `## Flowchart`, `## Mind Map`, `## Entity-Relationship Diagram`). Each section contains the diagram source in a fenced code block followed by an `**Export:**` annotation line. The code block language tag depends on the engine: `mermaid` for Mermaid diagrams, `markmap` for Markmap mind maps. This structure is uniform from the first write, so appending a second diagram type never requires restructuring.
 
 ```markdown
 ## Flowchart
@@ -173,12 +173,27 @@ flowchart TD
 **Export:** Classic theme, A4 landscape.
 ```
 
-Additional frontmatter field for diagram docs:
+```markdown
+## Mind Map
+
+```markmap
+# Topic
+## Branch 1
+## Branch 2
+```
+
+**Export:** Markmap engine, A4 landscape.
+```
+
+Additional frontmatter fields for diagram docs:
 
 ```yaml
+engine: markmap                                  # optional -- mermaid (default) | markmap
 source:                                          # always a YAML list, even for single sources
   - docs/brainstorms/YYYY-MM-DD-<topic>.md       # path(s) to origin document(s)
 ```
+
+The `engine` field is only needed when using a non-default engine (currently only Markmap for mind maps). Omit for Mermaid diagrams.
 
 ## File Naming Convention
 

--- a/plugins/cortex-engineering/skills/mermaid-diagrams/SKILL.md
+++ b/plugins/cortex-engineering/skills/mermaid-diagrams/SKILL.md
@@ -8,6 +8,8 @@ user-invocable: false
 
 Background knowledge for producing clean, readable, print-ready Mermaid diagrams. This skill provides the craft -- the **visualize** skill provides the workflow.
 
+**Scope:** Mermaid is the engine for all non-mind-map diagram types. Mind maps auto-route to Markmap via the visualize skill. Users can override to Mermaid for mind maps if they prefer themed presets over Markmap's visual quality.
+
 **Curated visual identity:** All diagrams use one of three preset configs. Each preset pairs a theme, look mode, and layout engine. See [default-theme.md](references/default-theme.md) for the full specification.
 
 ## Quick Start

--- a/plugins/cortex-engineering/skills/visualize/SKILL.md
+++ b/plugins/cortex-engineering/skills/visualize/SKILL.md
@@ -8,7 +8,7 @@ allowed-tools:
   - Bash(node *)
   - Bash(open *)
   - Bash(mkdir *)
-  - Bash(rm *.html)
+  - Bash(rm mindmap.html)
   - Read
   - Glob
   - Grep

--- a/plugins/cortex-engineering/skills/visualize/SKILL.md
+++ b/plugins/cortex-engineering/skills/visualize/SKILL.md
@@ -1,12 +1,14 @@
 ---
 name: visualize
-description: Generates Mermaid diagrams from any document, topic, or concept. Use when someone wants to visualize, diagram, or map out anything.
+description: Generates diagrams from any document, topic, or concept. Routes mind maps to Markmap, everything else to Mermaid. Use when someone wants to visualize, diagram, or map out anything.
 argument-hint: "<path, topic, or concept>"
 disable-model-invocation: true
 allowed-tools:
   - Bash(bunx *)
+  - Bash(node *)
   - Bash(open *)
   - Bash(mkdir *)
+  - Bash(rm *.html)
   - Read
   - Glob
   - Grep
@@ -15,9 +17,11 @@ allowed-tools:
 
 # Visualize
 
-Generate Mermaid diagrams from any document, topic, or concept. Export as print-ready SVG/PDF.
+Generate diagrams from any document, topic, or concept. Mind maps auto-route to Markmap for superior visual quality; all other diagram types use Mermaid. Export as print-ready SVG/PDF.
 
-**Companion skill:** The **mermaid-diagrams** skill is auto-loaded background knowledge. Do NOT pre-read its SKILL.md or references directory -- consult them only when you need specific information (classDef blocks in step 3, export commands in step 4). This skill handles the workflow; mermaid-diagrams provides the craft on demand.
+**Companion skills:**
+- **mermaid-diagrams** -- auto-loaded background knowledge for Mermaid craft. Consult only when you need specific info (classDef blocks in step 3, export commands in step 4).
+- **Markmap reference** (`engine-routing.md` in `visualize/references/`) -- theming config and known issues. Consult when generating mind maps via Markmap.
 
 ## Quick Start
 
@@ -25,7 +29,7 @@ Generate Mermaid diagrams from any document, topic, or concept. Export as print-
 /cortex-engineering:visualize docs/research/2026-03-01-some-topic.md
 ```
 
-Provide a file path, topic string, or invoke with no argument to use conversation context. The skill auto-detects diagram type, generates Mermaid, and exports to SVG/PDF.
+Provide a file path, topic string, or invoke with no argument to use conversation context. The skill auto-detects diagram type, routes to the appropriate engine, and exports to SVG/PDF.
 
 ## Workflow
 
@@ -38,14 +42,31 @@ Resolve from `$ARGUMENTS`:
 3. No argument: check conversation for the most recent Cortex doc, then ask the user.
 
 **Re-render shortcut:** If the source is an existing diagram directory (index.md with `type: diagram` in frontmatter):
-- If directory contains exactly one `.mmd` file: read it and skip to step 4 (export)
+- Read `index.md` frontmatter for `engine:` field
+- If `engine: markmap`: read `mindmap.mmd` as markdown, use Markmap pipeline (step 4)
+- If `engine: mermaid` or absent: read `.mmd` file as Mermaid syntax, use mmdc pipeline (step 4)
 - If directory contains multiple `.mmd` files: list them and ask which to re-render
 
 ### 2. Auto-detect and confirm
 
-Auto-detect diagram type from content (see type detection table in the mermaid-diagrams skill's default-theme reference). Present fast-path confirmation:
+Auto-detect diagram type from content (see type detection table in the mermaid-diagrams skill's default-theme reference). **Engine routing:** If the detected type is `mindmap`, default engine is Markmap. All other types default to Mermaid.
 
-> "I'll generate a **mind map** for **YAML Frontmatter Research**."
+Present fast-path confirmation:
+
+**For mind maps (Markmap default):**
+
+> "I'll generate a **mind map** for **[Topic]**."
+> Defaults: A4, Markmap engine.
+>
+> 1. Go (use defaults)
+> 2. A3 landscape (wall poster)
+> 3. Change style (Classic only for Markmap)
+> 4. Change diagram type
+> 5. Change engine (currently: Markmap)
+
+**For all other diagram types (Mermaid, no engine option):**
+
+> "I'll generate a **[type]** for **[Topic]**."
 > Defaults: A4, Classic style.
 >
 > 1. Go (use defaults)
@@ -53,17 +74,23 @@ Auto-detect diagram type from content (see type detection table in the mermaid-d
 > 3. Change style (Sketch / Blueprint)
 > 4. Change diagram type
 
+Option 5 only appears when the auto-detected type supports multiple engines (currently only mind maps).
+
 **Follow-up flows (one decision at a time):**
 
-If user picks **1** (Go): Use defaults (A4, Classic), proceed to step 3.
+If user picks **1** (Go): Use defaults, proceed to step 3.
 
 If user picks **2** (A3): Set paper to A3, proceed to step 3.
 
-If user picks **3** (Change style): Show preset sub-prompt:
+If user picks **3** (Change style):
 
+For Mermaid engine:
 > 1. Classic - bold colors, clean lines (default)
 > 2. Sketch - hand-drawn, warm tones (flowcharts + state only)
 > 3. Blueprint - monochrome, compact ELK layout (flowcharts + state only)
+
+For Markmap engine: show one-line note:
+> "Markmap uses Classic colors (Okabe-Ito palette); hand-drawn/ELK modes are Mermaid-only."
 
 After preset selection, proceed to step 3. If diagram type is NOT flowchart/state and user picked Sketch or Blueprint, show one-line note:
 
@@ -71,7 +98,15 @@ After preset selection, proceed to step 3. If diagram type is NOT flowchart/stat
 
 If user picks **4** (Change diagram type): Show current auto-detected type and ask what to change it to. After selection, proceed to step 3 (do NOT loop back to step 2).
 
-### 3. Generate Mermaid
+If user picks **5** (Change engine, mind maps only): Show engine sub-prompt:
+> 1. Markmap - curved branches, auto-colors, beautiful (default)
+> 2. Mermaid - basic shapes, themed presets (Classic/Sketch/Blueprint)
+
+After selection, proceed to step 3.
+
+### 3. Generate diagram source
+
+#### Mermaid engine (all non-mind-map types, or mind map with Mermaid override)
 
 Write Mermaid source directly. Rules:
 
@@ -82,9 +117,21 @@ Write Mermaid source directly. Rules:
 - Keep labels to 1-2 short lines using `<br/>` (not backtick syntax). Move verbose detail to edge labels or index.md.
 - For subgraphs with multiline titles: add an invisible spacer node (see mermaid-diagrams skill's config-engineering reference)
 
+#### Markmap engine (mind maps)
+
+Write standard markdown with heading-based hierarchy. Rules:
+
+- Root topic as `# Heading`
+- Branches as `##`, `###`, etc.
+- Max 3-5 main branches for readability
+- If source content exceeds 15 leaf nodes: summarize into key concepts first
+- Include Markmap JSON options in YAML frontmatter (see `engine-routing.md` reference for the Okabe-Ito color config)
+
 **Checkpoint:** Save `<type>.mmd` BEFORE attempting export. Save `index.md` using the detection logic in step 5 (first-write or append mode). Use the **frontmatter** skill for correct YAML frontmatter.
 
 ### 4. Export
+
+#### Mermaid engine
 
 Run mmdc with the preset's theme config. Use the paper size from step 2:
 
@@ -114,26 +161,51 @@ bunx @mermaid-js/mermaid-cli -i <type>.mmd -o <type>.pdf \
 
 Where `<PRESET>` is `default`, `sketch`, or `blueprint` based on the user's choice in step 2.
 
-Fallback chain: SVG + PDF -> SVG only -> .mmd source only. Always report what succeeded.
-
-**On syntax error:** Retry generation once with the error message as context. If still invalid, save .mmd source only and report the error.
-
 **If `bunx` fails:** Try `npx -p @mermaid-js/mermaid-cli mmdc` instead (Puppeteer has native Node.js dependencies that Bun may not resolve).
 
 **First-run note:** mmdc downloads Chromium (~150MB) on first use. If this fails, try system Chrome fallback. See the mermaid-diagrams skill's default-theme reference for troubleshooting.
+
+#### Markmap engine
+
+Two-step pipeline: generate HTML with markmap-cli, then extract SVG + PDF with Puppeteer. See `engine-routing.md` reference for full details.
+
+```bash
+# Step 1: Generate HTML with embedded SVG
+bunx markmap-cli --no-open --no-toolbar --offline -o mindmap.html mindmap.mmd
+
+# Step 2: Extract SVG + print PDF via Puppeteer
+node "$CLAUDE_PLUGIN_ROOT/skills/visualize/references/export-markmap.mjs" \
+  mindmap.html mindmap \
+  --css "$CLAUDE_PLUGIN_ROOT/skills/visualize/references/markmap-theme.css"
+
+# Step 3: Clean up intermediate HTML
+rm mindmap.html
+```
+
+Produces: `mindmap.svg` + `mindmap.pdf`
+
+**If `bunx` fails:** Try `npx markmap-cli` instead.
+
+#### Fallback chain (both engines)
+
+SVG + PDF -> SVG only -> .mmd source only. Always report what succeeded.
+
+**On syntax error (Mermaid):** Retry generation once with the error message as context. If still invalid, save .mmd source only and report the error.
+
+**No cross-engine fallback.** If Markmap fails, do NOT silently fall back to Mermaid. Report the failure and let the user choose.
 
 ### 5. Save
 
 Save to `docs/diagrams/YYYY-MM-DD-<topic-slug>/`:
 
-- `index.md` -- Mermaid source with frontmatter (via **frontmatter** skill)
-- `<type>.mmd` -- raw Mermaid source (for re-rendering)
+- `index.md` -- diagram source with frontmatter (via **frontmatter** skill)
+- `<type>.mmd` -- raw diagram source (for re-rendering)
 - `<type>.svg` -- screen/print viewing
 - `<type>.pdf` -- direct printing
 
-**Type-to-slug-to-label mapping** -- resolve `<type>` file slug and `## <Label>` section heading from the Mermaid diagram keyword:
+**Type-to-slug-to-label mapping** -- resolve `<type>` file slug and `## <Label>` section heading from the diagram type:
 
-| Mermaid type | File slug | Section heading label |
+| Diagram type | File slug | Section heading label |
 |---|---|---|
 | flowchart / graph | `flowchart` | Flowchart |
 | sequence | `sequence` | Sequence Diagram |
@@ -156,17 +228,27 @@ Save to `docs/diagrams/YYYY-MM-DD-<topic-slug>/`:
 | requirement | `requirement` | Requirement Diagram |
 | radar | `radar` | Radar Chart |
 
-**Label fallback:** If the Mermaid type is not in the table, derive the label by Title Casing the file slug (e.g. `waterfall` -> `## Waterfall`).
+**Label fallback:** If the diagram type is not in the table, derive the label by Title Casing the file slug (e.g. `waterfall` -> `## Waterfall`).
 
 **Topic slug:** lowercase, a-z/0-9/hyphens only, max 80 chars. Strip special characters, collapse whitespace to hyphens, trim leading/trailing hyphens. NEVER interpolate raw user input into shell commands -- sanitize the slug first, then use it in `mkdir -p`.
 
 Create `docs/diagrams/` with `mkdir -p` if needed.
 
-**What goes where:** `<type>.mmd` contains the full Mermaid source INCLUDING classDef lines. The `-c` config file provides theme variables (colors, fonts, spacing) -- separate from classDef. `index.md` embeds the same Mermaid in a fenced code block alongside YAML frontmatter.
+**What goes where:** `<type>.mmd` contains the full diagram source. For Mermaid: includes classDef lines; the `-c` config file provides theme variables separately. For Markmap: includes YAML frontmatter with color/spacing options. `index.md` embeds the same source in a fenced code block alongside YAML frontmatter.
+
+**Engine field:** When using Markmap, add `engine: markmap` to the `index.md` YAML frontmatter. This enables correct re-render detection in step 1. Omit for Mermaid (default).
 
 #### index.md write protocol
 
-Every `index.md` for `type: diagram` uses `## <Label>` section headings from the first write. Each section contains exactly: the fenced mermaid code block and an `**Export:** <preset> theme, <paper> size.` line. A section spans from its `## ` heading to the next `## ` heading or EOF.
+Every `index.md` for `type: diagram` uses `## <Label>` section headings from the first write. Each section contains exactly: the fenced code block and an `**Export:**` annotation line. A section spans from its `## ` heading to the next `## ` heading or EOF.
+
+**Code block language tag by engine:**
+- Mermaid: ` ```mermaid `
+- Markmap: ` ```markmap ` (enables Obsidian's markmap plugin for inline preview)
+
+**Export annotation format:**
+- Mermaid: `**Export:** Classic theme, A4 landscape.`
+- Markmap: `**Export:** Markmap engine, A4 landscape.`
 
 **Detection logic** -- before writing index.md:
 
@@ -196,7 +278,7 @@ When "Overwrite existing" is chosen for a same-type collision:
 
 ### 6. Report and open
 
-Report all file paths. Mention the chosen paper size ("Print the PDF at A4/A3"). Offer to open:
+Report all file paths. Mention the engine used and the chosen paper size (e.g. "Markmap mind map, print the PDF at A4"). For Markmap exports, add: "The SVG renders best in a browser; use the PDF for printing." Offer to open:
 
 > 1. Open diagram (SVG in browser)
 > 2. Open in Preview (PDF for print preview)
@@ -223,6 +305,7 @@ Say: "Diagram saved to `docs/diagrams/YYYY-MM-DD-<topic>/`".
 ## Example Frontmatter
 
 ```yaml
+# Mermaid diagram (engine field omitted -- default)
 ---
 created: 2026-03-01
 title: "Plugin Architecture Diagram"
@@ -235,9 +318,24 @@ source:
 ---
 ```
 
+```yaml
+# Markmap mind map (engine field explicit)
+---
+created: 2026-03-01
+title: "Cortex Engineering Mind Map"
+type: diagram
+engine: markmap
+tags: [architecture, cortex, mindmap]
+project: side-quest-marketplace
+status: draft
+source:
+  - docs/research/2026-03-01-cortex-overview.md
+---
+```
+
 ## Success Criteria
 
-- [ ] Mermaid source saved as `<type>.mmd` (always, even if export fails)
+- [ ] Diagram source saved as `<type>.mmd` (always, even if export fails)
 - [ ] `index.md` saved with valid YAML frontmatter
 - [ ] SVG and/or PDF exported successfully (or fallback reported)
 - [ ] All files saved to `docs/diagrams/YYYY-MM-DD-<topic-slug>/`
@@ -247,6 +345,6 @@ source:
 
 - **Visual context is instant** -- diagrams on the wall mean zero cognitive ramp-up
 - **Knowledge compounds** -- diagrams evolve alongside research and brainstorms
-- **Graceful degradation** -- always save the Mermaid source, even if export fails
+- **Graceful degradation** -- always save the diagram source, even if export fails
 - **Confirm before generating** -- always ask, never auto-invoke
 - **Curated visual identity** -- three presets, zero manual styling decisions

--- a/plugins/cortex-engineering/skills/visualize/references/engine-routing.md
+++ b/plugins/cortex-engineering/skills/visualize/references/engine-routing.md
@@ -1,0 +1,44 @@
+# Markmap Theming and Known Issues
+
+Reference for Markmap-specific theming and caveats. The visualize SKILL.md covers the full workflow (routing, generation, export, save). This file provides supplementary detail.
+
+## Okabe-Ito Color Palette
+
+Markmap JSON options in source `.mmd` YAML frontmatter (markmap-cli reads these automatically):
+
+```yaml
+---
+markmap:
+  color:
+    - '#0072B2'
+    - '#E69F00'
+    - '#009E73'
+    - '#D55E00'
+    - '#56B4E9'
+    - '#CC79A7'
+    - '#F0E442'
+  colorFreezeLevel: 2
+  maxWidth: 320
+  spacingVertical: 12
+  spacingHorizontal: 80
+  paddingX: 16
+---
+```
+
+## Theme CSS
+
+The `markmap-theme.css` file provides:
+- **Font**: Inter, Helvetica, Arial, sans-serif
+- **Typographic scale by depth**: Root 24px/700, L2 20px/600, L3 18px/500, L4+ 16px/400
+- **White background** for print
+- **Branch lines**: 2px stroke width
+- **Print color-adjust**: forces color rendering in print
+
+The CSS uses `!important` on font properties because markmap injects inline styles that must be overridden.
+
+## Known Issues
+
+1. **foreignObject rendering** -- Markmap uses HTML-in-SVG via `<foreignObject>` rather than SVG `<text>`. The extracted SVG renders best in a browser. For print-ready output, PDF is the better format.
+2. **D3 animation timing** -- The export script waits 2 seconds after `waitForSelector('svg')` for D3 transitions to complete. If you see clipped/missing nodes, increase the delay in `export-markmap.mjs`.
+3. **`--offline` is required** -- Without it, the HTML references CDN URLs that fail with `file://` protocol in Puppeteer.
+4. **Inline font scale duplication** -- The export script hardcodes the same typographic scale as `markmap-theme.css` because SVG `<style>` CSS does not reliably cross the namespace boundary into XHTML `<foreignObject>` content. The CSS file is the canonical source; keep the script values in sync if changing.

--- a/plugins/cortex-engineering/skills/visualize/references/export-markmap.mjs
+++ b/plugins/cortex-engineering/skills/visualize/references/export-markmap.mjs
@@ -1,0 +1,181 @@
+/**
+ * export-markmap.mjs
+ *
+ * Extracts SVG and PDF from a markmap-generated HTML file using Puppeteer.
+ * Injects a CSS theme file into the HTML before rendering so markmap
+ * calculates node sizes with the themed font metrics.
+ *
+ * Usage:
+ *   node export-markmap.mjs <input.html> [output-base] [--css theme.css]
+ *
+ * Produces:
+
+ *   <output-base>.svg  -- standalone SVG extracted from the DOM
+ *   <output-base>.pdf  -- print-ready PDF (A4 landscape)
+ */
+
+import { promises as fs } from 'node:fs'
+import path from 'node:path'
+import puppeteer from 'puppeteer'
+
+// Parse args
+const args = process.argv.slice(2)
+let htmlPath
+let outBase = 'mindmap'
+let cssPath
+
+for (let i = 0; i < args.length; i++) {
+	if (args[i] === '--css' && args[i + 1]) {
+		cssPath = args[++i]
+	} else if (!htmlPath) {
+		htmlPath = args[i]
+	} else {
+		outBase = args[i]
+	}
+}
+
+if (!htmlPath) {
+	console.error(
+		'Usage: node export-markmap.mjs <input.html> [output-base] [--css theme.css]',
+	)
+	process.exit(1)
+}
+
+// If CSS provided, inject it into the HTML before </head> so markmap
+// renders with themed font metrics (affects node bounding box calculations)
+let htmlContent = await fs.readFile(htmlPath, 'utf8')
+if (cssPath) {
+	const css = await fs.readFile(cssPath, 'utf8')
+	const styleTag = `<style>/* cortex-theme */\n${css}\n</style>`
+	htmlContent = htmlContent.replace('</head>', `${styleTag}\n</head>`)
+	console.log(`Injected theme CSS from ${cssPath}`)
+}
+
+// Write a temp HTML with injected styles
+const tmpHtml = path.resolve(
+	path.dirname(htmlPath),
+	'.markmap-themed-' + path.basename(htmlPath),
+)
+await fs.writeFile(tmpHtml, htmlContent, 'utf8')
+
+const absHtml = 'file://' + tmpHtml
+
+const browser = await puppeteer.launch({ headless: 'new' })
+const page = await browser.newPage()
+await page.goto(absHtml, { waitUntil: 'networkidle0' })
+
+// Wait for the SVG to render (markmap uses requestAnimationFrame)
+await page.waitForSelector('svg', { timeout: 10_000 })
+
+// Give markmap time to finish D3 transitions and size calculations
+await new Promise((r) => setTimeout(r, 2_000))
+
+// Trigger a fit-to-window so markmap recalculates with themed sizes
+await page.evaluate(() => {
+	const mm = window.markmap
+	if (mm?.fit) mm.fit()
+})
+await new Promise((r) => setTimeout(r, 500))
+
+// Extract the SVG as a valid standalone file
+const svgData = await page.evaluate(() => {
+	const svg = document.querySelector('svg')
+	const bbox = svg.getBBox()
+	const padding = 16
+
+	// Compute viewBox from the actual rendered content
+	const viewBox = [
+		bbox.x - padding,
+		bbox.y - padding,
+		bbox.width + padding * 2,
+		bbox.height + padding * 2,
+	].join(' ')
+
+	// Clone the SVG so we can mutate it
+	const clone = svg.cloneNode(true)
+
+	// Add required namespaces for standalone SVG
+	clone.setAttribute('xmlns', 'http://www.w3.org/2000/svg')
+	clone.setAttribute('xmlns:xlink', 'http://www.w3.org/1999/xlink')
+	clone.setAttribute('xmlns:fo', 'http://www.w3.org/1999/xhtml')
+	clone.setAttribute('viewBox', viewBox)
+	clone.setAttribute('width', Math.ceil(bbox.width + padding * 2))
+	clone.setAttribute('height', Math.ceil(bbox.height + padding * 2))
+
+	// Add white background rect as first child (before all content)
+	// Use explicit viewBox coordinates -- percentage-based width/height starts
+	// at SVG coordinate (0,0), not the viewBox origin, leaving gaps when
+	// the viewBox has negative x/y offsets.
+	const bgRect = document.createElementNS('http://www.w3.org/2000/svg', 'rect')
+	bgRect.setAttribute('x', String(bbox.x - padding))
+	bgRect.setAttribute('y', String(bbox.y - padding))
+	bgRect.setAttribute('width', String(bbox.width + padding * 2))
+	bgRect.setAttribute('height', String(bbox.height + padding * 2))
+	bgRect.setAttribute('fill', '#ffffff')
+	clone.insertBefore(bgRect, clone.firstChild)
+
+	// Remove markmap-specific class/style that depend on external context
+	clone.removeAttribute('class')
+	clone.removeAttribute('id')
+
+	// Resolve CSS custom properties into concrete values within the style block
+	const styleEl = clone.querySelector('style')
+	if (styleEl) {
+		const computed = window.getComputedStyle(svg)
+		let cssText = styleEl.textContent
+		// Replace var(--markmap-*) references with computed values
+		cssText = cssText.replace(/var\(--([^)]+)\)/g, (match, varName) => {
+			const val = computed.getPropertyValue('--' + varName).trim()
+			return val || match
+		})
+		styleEl.textContent = cssText
+	}
+
+	// Typographic scale by depth (from design-system skill)
+	const fontScale = {
+		1: 'font-family:Inter,Helvetica,Arial,sans-serif;font-size:24px;line-height:32px;font-weight:700;color:#000;',
+		2: 'font-family:Inter,Helvetica,Arial,sans-serif;font-size:20px;line-height:28px;font-weight:600;color:#000;',
+		3: 'font-family:Inter,Helvetica,Arial,sans-serif;font-size:18px;line-height:24px;font-weight:500;color:#000;',
+		default:
+			'font-family:Inter,Helvetica,Arial,sans-serif;font-size:16px;line-height:24px;font-weight:400;color:#000;',
+	}
+
+	// Apply inline styles to each foreignObject div -- SVG <style> CSS
+	// does not reliably cross the namespace boundary into XHTML content
+	for (const node of clone.querySelectorAll('.markmap-node, [data-depth]')) {
+		const depth = node.getAttribute('data-depth')
+		const style = fontScale[depth] || fontScale.default
+		for (const div of node.querySelectorAll('foreignObject div')) {
+			div.setAttribute('style', style)
+			if (!div.getAttribute('xmlns')) {
+				div.setAttribute('xmlns', 'http://www.w3.org/1999/xhtml')
+			}
+		}
+	}
+
+	return clone.outerHTML
+})
+
+const svgFile = '<?xml version="1.0" encoding="UTF-8"?>\n' + svgData
+await fs.writeFile(`${outBase}.svg`, svgFile, 'utf8')
+console.log(
+	`SVG written to ${outBase}.svg (${(svgFile.length / 1024).toFixed(1)}KB)`,
+)
+
+// Generate PDF -- A4 landscape with margins
+await page.pdf({
+	path: `${outBase}.pdf`,
+	format: 'A4',
+	landscape: true,
+	printBackground: true,
+	margin: { top: '10mm', right: '10mm', bottom: '10mm', left: '10mm' },
+})
+const pdfStat = await fs.stat(`${outBase}.pdf`)
+console.log(
+	`PDF written to ${outBase}.pdf (${(pdfStat.size / 1024).toFixed(1)}KB)`,
+)
+
+await browser.close()
+
+// Clean up temp file
+await fs.unlink(tmpHtml).catch(() => {})

--- a/plugins/cortex-engineering/skills/visualize/references/export-markmap.mjs
+++ b/plugins/cortex-engineering/skills/visualize/references/export-markmap.mjs
@@ -16,6 +16,7 @@
 
 import { promises as fs } from 'node:fs'
 import path from 'node:path'
+import { pathToFileURL } from 'node:url'
 import puppeteer from 'puppeteer'
 
 // Parse args
@@ -58,124 +59,128 @@ const tmpHtml = path.resolve(
 )
 await fs.writeFile(tmpHtml, htmlContent, 'utf8')
 
-const absHtml = 'file://' + tmpHtml
+const absHtml = pathToFileURL(tmpHtml).href
 
-const browser = await puppeteer.launch({ headless: 'new' })
-const page = await browser.newPage()
-await page.goto(absHtml, { waitUntil: 'networkidle0' })
+let browser
+try {
+	browser = await puppeteer.launch({ headless: 'new' })
+	const page = await browser.newPage()
+	await page.goto(absHtml, { waitUntil: 'networkidle0' })
 
-// Wait for the SVG to render (markmap uses requestAnimationFrame)
-await page.waitForSelector('svg', { timeout: 10_000 })
+	// Wait for the SVG to render (markmap uses requestAnimationFrame)
+	await page.waitForSelector('svg', { timeout: 10_000 })
 
-// Give markmap time to finish D3 transitions and size calculations
-await new Promise((r) => setTimeout(r, 2_000))
+	// Give markmap time to finish D3 transitions and size calculations
+	await new Promise((r) => setTimeout(r, 2_000))
 
-// Trigger a fit-to-window so markmap recalculates with themed sizes
-await page.evaluate(() => {
-	const mm = window.markmap
-	if (mm?.fit) mm.fit()
-})
-await new Promise((r) => setTimeout(r, 500))
+	// Trigger a fit-to-window so markmap recalculates with themed sizes
+	await page.evaluate(() => {
+		const mm = window.markmap
+		if (mm?.fit) mm.fit()
+	})
+	await new Promise((r) => setTimeout(r, 500))
 
-// Extract the SVG as a valid standalone file
-const svgData = await page.evaluate(() => {
-	const svg = document.querySelector('svg')
-	const bbox = svg.getBBox()
-	const padding = 16
+	// Extract the SVG as a valid standalone file
+	const svgData = await page.evaluate(() => {
+		const svg = document.querySelector('svg')
+		const bbox = svg.getBBox()
+		const padding = 16
 
-	// Compute viewBox from the actual rendered content
-	const viewBox = [
-		bbox.x - padding,
-		bbox.y - padding,
-		bbox.width + padding * 2,
-		bbox.height + padding * 2,
-	].join(' ')
+		// Compute viewBox from the actual rendered content
+		const viewBox = [
+			bbox.x - padding,
+			bbox.y - padding,
+			bbox.width + padding * 2,
+			bbox.height + padding * 2,
+		].join(' ')
 
-	// Clone the SVG so we can mutate it
-	const clone = svg.cloneNode(true)
+		// Clone the SVG so we can mutate it
+		const clone = svg.cloneNode(true)
 
-	// Add required namespaces for standalone SVG
-	clone.setAttribute('xmlns', 'http://www.w3.org/2000/svg')
-	clone.setAttribute('xmlns:xlink', 'http://www.w3.org/1999/xlink')
-	clone.setAttribute('xmlns:fo', 'http://www.w3.org/1999/xhtml')
-	clone.setAttribute('viewBox', viewBox)
-	clone.setAttribute('width', Math.ceil(bbox.width + padding * 2))
-	clone.setAttribute('height', Math.ceil(bbox.height + padding * 2))
+		// Add required namespaces for standalone SVG
+		clone.setAttribute('xmlns', 'http://www.w3.org/2000/svg')
+		clone.setAttribute('xmlns:xlink', 'http://www.w3.org/1999/xlink')
+		clone.setAttribute('xmlns:fo', 'http://www.w3.org/1999/xhtml')
+		clone.setAttribute('viewBox', viewBox)
+		clone.setAttribute('width', Math.ceil(bbox.width + padding * 2))
+		clone.setAttribute('height', Math.ceil(bbox.height + padding * 2))
 
-	// Add white background rect as first child (before all content)
-	// Use explicit viewBox coordinates -- percentage-based width/height starts
-	// at SVG coordinate (0,0), not the viewBox origin, leaving gaps when
-	// the viewBox has negative x/y offsets.
-	const bgRect = document.createElementNS('http://www.w3.org/2000/svg', 'rect')
-	bgRect.setAttribute('x', String(bbox.x - padding))
-	bgRect.setAttribute('y', String(bbox.y - padding))
-	bgRect.setAttribute('width', String(bbox.width + padding * 2))
-	bgRect.setAttribute('height', String(bbox.height + padding * 2))
-	bgRect.setAttribute('fill', '#ffffff')
-	clone.insertBefore(bgRect, clone.firstChild)
+		// Add white background rect as first child (before all content)
+		// Use explicit viewBox coordinates -- percentage-based width/height starts
+		// at SVG coordinate (0,0), not the viewBox origin, leaving gaps when
+		// the viewBox has negative x/y offsets.
+		const bgRect = document.createElementNS(
+			'http://www.w3.org/2000/svg',
+			'rect',
+		)
+		bgRect.setAttribute('x', String(bbox.x - padding))
+		bgRect.setAttribute('y', String(bbox.y - padding))
+		bgRect.setAttribute('width', String(bbox.width + padding * 2))
+		bgRect.setAttribute('height', String(bbox.height + padding * 2))
+		bgRect.setAttribute('fill', '#ffffff')
+		clone.insertBefore(bgRect, clone.firstChild)
 
-	// Remove markmap-specific class/style that depend on external context
-	clone.removeAttribute('class')
-	clone.removeAttribute('id')
+		// Remove markmap-specific class/style that depend on external context
+		clone.removeAttribute('class')
+		clone.removeAttribute('id')
 
-	// Resolve CSS custom properties into concrete values within the style block
-	const styleEl = clone.querySelector('style')
-	if (styleEl) {
-		const computed = window.getComputedStyle(svg)
-		let cssText = styleEl.textContent
-		// Replace var(--markmap-*) references with computed values
-		cssText = cssText.replace(/var\(--([^)]+)\)/g, (match, varName) => {
-			const val = computed.getPropertyValue('--' + varName).trim()
-			return val || match
-		})
-		styleEl.textContent = cssText
-	}
+		// Resolve CSS custom properties into concrete values within the style block
+		const styleEl = clone.querySelector('style')
+		if (styleEl) {
+			const computed = window.getComputedStyle(svg)
+			let cssText = styleEl.textContent
+			// Replace var(--markmap-*) references with computed values
+			cssText = cssText.replace(/var\(--([^)]+)\)/g, (match, varName) => {
+				const val = computed.getPropertyValue('--' + varName).trim()
+				return val || match
+			})
+			styleEl.textContent = cssText
+		}
 
-	// Typographic scale by depth (from design-system skill)
-	const fontScale = {
-		1: 'font-family:Inter,Helvetica,Arial,sans-serif;font-size:24px;line-height:32px;font-weight:700;color:#000;',
-		2: 'font-family:Inter,Helvetica,Arial,sans-serif;font-size:20px;line-height:28px;font-weight:600;color:#000;',
-		3: 'font-family:Inter,Helvetica,Arial,sans-serif;font-size:18px;line-height:24px;font-weight:500;color:#000;',
-		default:
-			'font-family:Inter,Helvetica,Arial,sans-serif;font-size:16px;line-height:24px;font-weight:400;color:#000;',
-	}
+		// Typographic scale by depth (from design-system skill)
+		const fontScale = {
+			1: 'font-family:Inter,Helvetica,Arial,sans-serif;font-size:24px;line-height:32px;font-weight:700;color:#000;',
+			2: 'font-family:Inter,Helvetica,Arial,sans-serif;font-size:20px;line-height:28px;font-weight:600;color:#000;',
+			3: 'font-family:Inter,Helvetica,Arial,sans-serif;font-size:18px;line-height:24px;font-weight:500;color:#000;',
+			default:
+				'font-family:Inter,Helvetica,Arial,sans-serif;font-size:16px;line-height:24px;font-weight:400;color:#000;',
+		}
 
-	// Apply inline styles to each foreignObject div -- SVG <style> CSS
-	// does not reliably cross the namespace boundary into XHTML content
-	for (const node of clone.querySelectorAll('.markmap-node, [data-depth]')) {
-		const depth = node.getAttribute('data-depth')
-		const style = fontScale[depth] || fontScale.default
-		for (const div of node.querySelectorAll('foreignObject div')) {
-			div.setAttribute('style', style)
-			if (!div.getAttribute('xmlns')) {
-				div.setAttribute('xmlns', 'http://www.w3.org/1999/xhtml')
+		// Apply inline styles to each foreignObject div -- SVG <style> CSS
+		// does not reliably cross the namespace boundary into XHTML content
+		for (const node of clone.querySelectorAll('.markmap-node, [data-depth]')) {
+			const depth = node.getAttribute('data-depth')
+			const style = fontScale[depth] || fontScale.default
+			for (const div of node.querySelectorAll('foreignObject div')) {
+				div.setAttribute('style', style)
+				if (!div.getAttribute('xmlns')) {
+					div.setAttribute('xmlns', 'http://www.w3.org/1999/xhtml')
+				}
 			}
 		}
-	}
 
-	return clone.outerHTML
-})
+		return clone.outerHTML
+	})
 
-const svgFile = '<?xml version="1.0" encoding="UTF-8"?>\n' + svgData
-await fs.writeFile(`${outBase}.svg`, svgFile, 'utf8')
-console.log(
-	`SVG written to ${outBase}.svg (${(svgFile.length / 1024).toFixed(1)}KB)`,
-)
+	const svgFile = '<?xml version="1.0" encoding="UTF-8"?>\n' + svgData
+	await fs.writeFile(`${outBase}.svg`, svgFile, 'utf8')
+	console.log(
+		`SVG written to ${outBase}.svg (${(svgFile.length / 1024).toFixed(1)}KB)`,
+	)
 
-// Generate PDF -- A4 landscape with margins
-await page.pdf({
-	path: `${outBase}.pdf`,
-	format: 'A4',
-	landscape: true,
-	printBackground: true,
-	margin: { top: '10mm', right: '10mm', bottom: '10mm', left: '10mm' },
-})
-const pdfStat = await fs.stat(`${outBase}.pdf`)
-console.log(
-	`PDF written to ${outBase}.pdf (${(pdfStat.size / 1024).toFixed(1)}KB)`,
-)
-
-await browser.close()
-
-// Clean up temp file
-await fs.unlink(tmpHtml).catch(() => {})
+	// Generate PDF -- A4 landscape with margins
+	await page.pdf({
+		path: `${outBase}.pdf`,
+		format: 'A4',
+		landscape: true,
+		printBackground: true,
+		margin: { top: '10mm', right: '10mm', bottom: '10mm', left: '10mm' },
+	})
+	const pdfStat = await fs.stat(`${outBase}.pdf`)
+	console.log(
+		`PDF written to ${outBase}.pdf (${(pdfStat.size / 1024).toFixed(1)}KB)`,
+	)
+} finally {
+	if (browser) await browser.close().catch(() => {})
+	await fs.unlink(tmpHtml).catch(() => {})
+}

--- a/plugins/cortex-engineering/skills/visualize/references/markmap-theme.css
+++ b/plugins/cortex-engineering/skills/visualize/references/markmap-theme.css
@@ -1,0 +1,110 @@
+/*
+ * Cortex Engineering -- Markmap Classic Theme
+ *
+ * Aligns markmap output with the design-system skill tokens:
+ *   - Font: Inter, Helvetica, Arial, sans-serif
+ *   - Spacing: 8px grid
+ *   - Colors: Okabe-Ito colorblind-safe palette
+ *   - Background: white (print-ready)
+ *   - WCAG AA contrast on all text
+ *
+ * Markmap DOM structure:
+ *   g.markmap-node[data-depth="N"]
+ *     > line (branch connector)
+ *     > circle (fold indicator)
+ *     > foreignObject.markmap-foreign
+ *       > div > div (text content)
+ */
+
+/* ── Background ───────────────────────────────────────── */
+body,
+html {
+	margin: 0;
+	padding: 0;
+	background: #ffffff;
+}
+
+/* ── Typography base ──────────────────────────────────── */
+.markmap {
+	font-family: Inter, Helvetica, Arial, sans-serif;
+}
+
+.markmap foreignObject div {
+	font-family: Inter, Helvetica, Arial, sans-serif !important;
+	color: #000000 !important;
+}
+
+/* ── Typographic scale by depth ───────────────────────── */
+
+/* Depth 1: Root node -- Display (24px / 32px / 700) */
+[data-depth="1"] foreignObject div {
+	font-size: 24px !important;
+	line-height: 32px !important;
+	font-weight: 700 !important;
+}
+
+/* Depth 2: Primary branches -- Heading (20px / 28px / 600) */
+[data-depth="2"] foreignObject div {
+	font-size: 20px !important;
+	line-height: 28px !important;
+	font-weight: 600 !important;
+}
+
+/* Depth 3: Secondary branches -- Large (18px / 24px / 500) */
+[data-depth="3"] foreignObject div {
+	font-size: 18px !important;
+	line-height: 24px !important;
+	font-weight: 500 !important;
+}
+
+/* Depth 4+: Leaf nodes -- Base (16px / 24px / 400) */
+[data-depth="4"] foreignObject div,
+[data-depth="5"] foreignObject div,
+[data-depth="6"] foreignObject div {
+	font-size: 16px !important;
+	line-height: 24px !important;
+	font-weight: 400 !important;
+}
+
+/* ── Code spans inside nodes ──────────────────────────── */
+.markmap code {
+	font-size: 14px !important;
+	background: #f0f0f0 !important;
+	color: #333333 !important;
+	padding: 2px 6px !important;
+	border-radius: 4px !important;
+	font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace !important;
+}
+
+/* ── Branch lines -- consistent 2px stroke ────────────── */
+.markmap-link {
+	stroke-width: 2px !important;
+}
+
+/* Connector line under each node label */
+.markmap-node > line {
+	stroke-width: 2px !important;
+}
+
+/* ── Node circles -- visible, filled with branch color ── */
+.markmap-node circle {
+	stroke-width: 1.5px !important;
+	r: 4px;
+}
+
+/* ── Print: force color rendering ─────────────────────── */
+@media print {
+	body,
+	html {
+		background: #ffffff !important;
+		-webkit-print-color-adjust: exact !important;
+		print-color-adjust: exact !important;
+	}
+
+	.markmap-link,
+	.markmap-node circle,
+	.markmap-node line {
+		-webkit-print-color-adjust: exact !important;
+		print-color-adjust: exact !important;
+	}
+}


### PR DESCRIPTION
## Summary

- Routes mind map requests to Markmap by default, replacing Mermaid's experimental `mindmap` type with a purpose-built renderer (curved branches, auto-colors by depth, Okabe-Ito palette)
- All other diagram types continue to use Mermaid unchanged
- Users can override the engine at the step 2 confirmation prompt (option 5, mind maps only)
- Unified artifact contract: `mindmap.mmd` + `mindmap.svg` + `mindmap.pdf` regardless of engine
- Export pipeline validated by spike on `spike/markmap-export`: markmap-cli -> HTML -> Puppeteer -> SVG + PDF

## Changes

| File | Change |
|------|--------|
| `visualize/SKILL.md` | Steps 1-6 updated for dual-engine workflow (detection, prompt, generation, export, save, report) |
| `visualize/references/engine-routing.md` | New -- Markmap theming config (Okabe-Ito palette, spacing) and known issues |
| `visualize/references/export-markmap.mjs` | New -- Puppeteer script: injects theme CSS, waits for D3 transitions, extracts SVG + prints PDF |
| `visualize/references/markmap-theme.css` | New -- Design-system aligned theme (Inter font, typographic scale by depth, print support) |
| `frontmatter/SKILL.md` | Added `engine:` field to diagram doc type; updated section format docs for both engines |
| `mermaid-diagrams/SKILL.md` | Added scope clarification: Mermaid for all non-mind-map types |
| `.claude-plugin/plugin.json` | Version bump 0.4.1 -> 0.5.0 (minor: new capability) |
| `biome.json` | Exclude `.worktrees/` from Biome scan (fixes nested root config error) |

## Key Design Decisions

- **No cross-engine fallback** -- if Markmap fails, report it and let the user choose. Silent engine switching defeats the quality purpose.
- **`--offline` flag required** -- inlines all JS/CSS assets so `file://` protocol works in Puppeteer
- **foreignObject caveat surfaced in step 6** -- SVG renders best in a browser; PDF is the print format
- **engine-routing.md is theming + known issues only** -- pipeline commands stay in SKILL.md following progressive disclosure pattern
- **Companion skill deferred (YAGNI)** -- Markmap craft lives in `visualize/references/` until it warrants promotion

## Testing

- Export pipeline validated by spike (`spike/markmap-export` branch): SVG + PDF both produce quality output
- `bun run validate` passes (exit 0)
- CSS `!important` warnings are expected -- required to override markmap's inline styles

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: this change is plugin skill/workflow documentation with no production service runtime in this repository.

---

[![Compound Engineered](https://img.shields.io/badge/Compound-Engineered-6366f1)](https://github.com/EveryInc/compound-engineering-plugin) 🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mind Map diagrams now auto-route to a Markmap engine with an option to override; export parity added (standalone SVG + PDF + source).
  * Themed Markmap visuals aligned to the design system for consistent look in exports.

* **Documentation**
  * Updated docs and guides describing engine routing, export workflow, theming, and frontmatter usage.

* **Chores**
  * Version bumped to 0.5.0 and updated directory exclusion rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->