### PR TITLE
fix(config): exclude plugins/git and spike from root tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,5 +5,5 @@
 		"noEmit": true
 	},
 	"include": ["src/**/*.ts", "scripts/**/*.ts", "plugins/**/*.ts"],
-	"exclude": ["node_modules", "dist"]
+	"exclude": ["node_modules", "dist", "plugins/git", "spike"]
 }


### PR DESCRIPTION
## Summary
- Excludes `plugins/git` from root `tsc --noEmit` -- hooks use Bun types with their own compilation context
- Excludes `spike` directory containing experimental code

## Test plan
- [ ] `bun run typecheck` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated TypeScript compilation configuration to exclude additional directories from the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->