### PR TITLE
fix(dx-git): apply review findings to phase 4 commands

### DIFF
--- a/plugins/dx-git/.claude-plugin/plugin.json
+++ b/plugins/dx-git/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
 	"name": "dx-git",
 	"description": "Enforces conventional commits, blocks destructive git operations, and automates the commit-push-PR workflow",
-	"version": "3.0.0",
+	"version": "3.1.0",
 	"author": {
 		"name": "Nathan Vale"
 	},

--- a/plugins/dx-git/commands/clean-gone.md
+++ b/plugins/dx-git/commands/clean-gone.md
@@ -1,7 +1,7 @@
 ---
 description: Delete local branches whose remote tracking branch is gone
 model: sonnet
-allowed-tools: Bash(git fetch:*), Bash(git for-each-ref:*), Bash(git branch -d:*), Bash(git worktree list:*), Bash(git worktree prune:*), Bash(git worktree remove:*), Bash(git rev-parse:*), Bash(git symbolic-ref:*), Bash(git merge-tree:*), Bash(git commit-tree:*), Bash(git merge-base:*), Bash(git config --get:*), Bash(git config --get-all:*), Bash(gh repo view:*)
+allowed-tools: Bash(git fetch:*), Bash(git for-each-ref:*), Bash(git branch -d:*), Bash(git worktree list:*), Bash(git worktree prune:*), Bash(git worktree remove:*), Bash(git rev-parse:*), Bash(git symbolic-ref:*), Bash(git commit-tree:*), Bash(git merge-base:*), Bash(git config --get:*), Bash(git config --get-all:*), Bash(gh repo view:*)
 argument-hint: "[--confirm]"
 ---
 

--- a/plugins/dx-git/commands/commit-push-pr.md
+++ b/plugins/dx-git/commands/commit-push-pr.md
@@ -1,7 +1,7 @@
 ---
 description: Commit, push, and create a pull request in one workflow
 model: sonnet
-allowed-tools: Bash(git status:*), Bash(git add:*), Bash(git diff:*), Bash(git log:*), Bash(git commit:*), Bash(git push:*), Bash(git reset --soft:*), Bash(git merge-base:*), Bash(git branch --show-current:*), Bash(git symbolic-ref:*), Bash(git rev-list:*), Bash(git fetch:*), Bash(git remote:*), Bash(git config --get:*), Bash(gh pr create:*), Bash(gh pr list:*), Bash(gh pr view:*), Bash(gh repo view:*), Bash(gh auth:*), Bash(bun run validate:*)
+allowed-tools: Bash(git status:*), Bash(git add:*), Bash(git diff:*), Bash(git log:*), Bash(git commit:*), Bash(git push:*), Bash(git reset --soft:*), Bash(git merge-base:*), Bash(git branch --show-current:*), Bash(git symbolic-ref:*), Bash(git rev-list:*), Bash(git fetch:*), Bash(git remote:*), Bash(git config --get:*), Bash(gh pr create:*), Bash(gh pr list:*), Bash(gh pr view:*), Bash(gh repo view:*), Bash(gh auth status:*), Bash(bun run validate:*)
 argument-hint: "[description] [--draft] [--skip-validate]"
 ---
 


### PR DESCRIPTION
## Summary

- Remove `Bash(git merge-tree:*)` from `clean-gone.md` allowed-tools (unreferenced by any workflow step)
- Narrow `Bash(gh auth:*)` to `Bash(gh auth status:*)` in `commit-push-pr.md` (eliminates `gh auth token` surface)
- Bump plugin version to `3.1.0` (minor -- additive new commands, required by marketplace validation)

Follow-up to #23 based on multi-agent code review findings (pattern recognition, architecture, security, simplicity).

## Test plan

- [ ] `bun run validate` passes
- [ ] `bun test plugins/dx-git/` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added new workflow skill for committing, pushing, and creating pull requests in one workflow.

* **Documentation**
  * Updated command documentation with clearer usage instructions.
  * Refined workflow skill guidance for cleaning up local branches.

* **Chores**
  * Version bumped to 3.1.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->