### PR TITLE
feat(dx-biome-runner): add Biome linter/formatter plugin to marketplace

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://code.claude.com/docs/en/plugin-marketplaces",
 	"name": "side-quest-marketplace",
-	"version": "1.1.0",
+	"version": "1.2.0",
 	"description": "Agent-native knowledge system with research, brainstorm, and knowledge capture skills",
 	"owner": {
 		"name": "Nathan Vale",
@@ -35,6 +35,13 @@
 			"description": "TypeScript type checker MCP server with post-edit hooks for Claude Code",
 			"category": "development",
 			"tags": ["typescript", "tsc", "type-checking", "hooks", "mcp"]
+		},
+		{
+			"name": "dx-biome-runner",
+			"source": "./plugins/dx-biome-runner",
+			"description": "Biome linter and formatter MCP server with post-edit hooks for Claude Code",
+			"category": "development",
+			"tags": ["biome", "linting", "formatting", "hooks", "mcp"]
 		},
 		{
 			"name": "kb-mpe",

--- a/plugins/dx-biome-runner/.claude-plugin/plugin.json
+++ b/plugins/dx-biome-runner/.claude-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+	"name": "dx-biome-runner",
+	"description": "Runs Biome linting and formatting after every edit and at session end, surfacing diagnostics inline",
+	"version": "1.0.0",
+	"author": { "name": "Nathan Vale" },
+	"repository": "https://github.com/nathanvale/side-quest-marketplace",
+	"keywords": ["biome", "linting", "formatting", "diagnostics", "hooks"],
+	"license": "MIT",
+	"commands": ["./commands/show-logs.md"]
+}

--- a/plugins/dx-biome-runner/.mcp.json
+++ b/plugins/dx-biome-runner/.mcp.json
@@ -1,0 +1,8 @@
+{
+	"mcpServers": {
+		"biome-runner": {
+			"command": "bunx",
+			"args": ["@side-quest/biome-runner"]
+		}
+	}
+}

--- a/plugins/dx-biome-runner/README.md
+++ b/plugins/dx-biome-runner/README.md
@@ -16,7 +16,7 @@ Biome linter and formatter with post-edit hooks and an MCP server for on-demand 
 
 The MCP tools are provided by the `@side-quest/biome-runner` npm package. Use `response_format: "json"` for structured output:
 
-```
+```typescript
 biome_lintCheck({ response_format: "json" })
 biome_lintFix({ response_format: "json" })
 biome_formatCheck({ response_format: "json" })
@@ -34,8 +34,7 @@ biome_formatCheck({ response_format: "json" })
 
 **Stop (biome-ci.ts)**
 - Fires at session end
-- Runs full project-wide Biome check (all errors, not just edited files)
-- Detects Bun workspaces and runs `bun run --filter * check` if present
+- Runs `biome check --reporter=json` on the project root (all errors, not just edited files)
 - Skips if no Biome-relevant files were changed
 - Checks `stop_hook_active` to prevent infinite loops
 - 120s timeout, exits cleanly on timeout (non-blocking)

--- a/plugins/dx-biome-runner/README.md
+++ b/plugins/dx-biome-runner/README.md
@@ -1,0 +1,55 @@
+# dx-biome-runner Plugin for Claude Code
+
+Biome linter and formatter with post-edit hooks and an MCP server for on-demand checks.
+
+## Components
+
+| Component | Mechanism | Trigger | Behavior |
+|-----------|-----------|---------|----------|
+| `biome_lintCheck` MCP tool | JSON-RPC over stdio | On-demand | Structured JSON with lint diagnostics |
+| `biome_lintFix` MCP tool | JSON-RPC over stdio | On-demand | Auto-fix lint and format issues |
+| `biome_formatCheck` MCP tool | JSON-RPC over stdio | On-demand | Check formatting without changes |
+| PostToolUse hook | Shell script via bun | Write/Edit/MultiEdit | Blocks on errors in edited files only |
+| Stop hook | Shell script via bun | Session end | Blocks on any project-wide errors |
+
+## MCP Tools
+
+The MCP tools are provided by the `@side-quest/biome-runner` npm package. Use `response_format: "json"` for structured output:
+
+```
+biome_lintCheck({ response_format: "json" })
+biome_lintFix({ response_format: "json" })
+biome_formatCheck({ response_format: "json" })
+```
+
+## Hook Behavior
+
+**PostToolUse (biome-check.ts)**
+- Fires after every Write, Edit, or MultiEdit on supported files
+- Supported extensions: `.ts`, `.tsx`, `.js`, `.jsx`, `.json`, `.jsonc`, `.css`
+- Runs `biome check --reporter=json` on the specific edited files
+- Only blocks on errors (warnings are allowed through)
+- Returns structured JSON with `decision: "block"` and diagnostic details
+- 30s timeout, exits cleanly on timeout (non-blocking)
+
+**Stop (biome-ci.ts)**
+- Fires at session end
+- Runs full project-wide Biome check (all errors, not just edited files)
+- Detects Bun workspaces and runs `bun run --filter * check` if present
+- Skips if no Biome-relevant files were changed
+- Checks `stop_hook_active` to prevent infinite loops
+- 120s timeout, exits cleanly on timeout (non-blocking)
+
+## Commands
+
+- `/dx-biome-runner:show-logs` -- View MCP server and hook logs from `~/.claude/logs/biome-runner.jsonl`
+
+## Prerequisites
+
+- [Bun](https://bun.sh/) runtime
+- Project with `biome.json` configuration
+- `@side-quest/biome-runner` npm package (for MCP tools)
+
+## License
+
+MIT

--- a/plugins/dx-biome-runner/commands/show-logs.md
+++ b/plugins/dx-biome-runner/commands/show-logs.md
@@ -2,7 +2,7 @@
 description: View biome-runner MCP server and hook logs
 model: haiku
 allowed-tools: Read
-argument-hint: "[count=N] [level=LEVEL] [errors]"
+argument-hint: "[count=N] [level=LEVEL] [errors] [cid=ID]"
 ---
 
 Read the log file at `~/.claude/logs/biome-runner.jsonl` and display recent entries. $ARGUMENTS

--- a/plugins/dx-biome-runner/commands/show-logs.md
+++ b/plugins/dx-biome-runner/commands/show-logs.md
@@ -1,0 +1,18 @@
+---
+description: View biome-runner MCP server and hook logs
+model: haiku
+allowed-tools: Read
+argument-hint: "[count=N] [level=LEVEL] [errors]"
+---
+
+Read the log file at `~/.claude/logs/biome-runner.jsonl` and display recent entries. $ARGUMENTS
+
+**Arguments:**
+- `count=N` -- Show last N entries (default: 20)
+- `level=LEVEL` -- Filter by log level (DEBUG, INFO, WARN, ERROR)
+- `errors` -- Shorthand for `level=ERROR`
+- `cid=ID` -- Filter by correlation ID
+
+**Format:** Each line is a JSON object with fields: `timestamp`, `level`, `message`, `cid`, and additional context fields.
+
+Display results in a compact table format showing timestamp, level, and message.

--- a/plugins/dx-biome-runner/hooks/biome-check.ts
+++ b/plugins/dx-biome-runner/hooks/biome-check.ts
@@ -36,6 +36,11 @@ interface BiomeDiagnostic {
 	severity: 'error' | 'warning'
 }
 
+interface ParsedLineLocation {
+	span?: unknown
+	sourceCode?: string
+}
+
 /** Extract unique file paths from hook input (Write, Edit, MultiEdit). */
 function extractFilePaths(input: HookInput): string[] {
 	const seen = new Set<string>()
@@ -47,6 +52,50 @@ function extractFilePaths(input: HookInput): string[] {
 }
 
 /** Parse Biome JSON reporter output into structured diagnostics. */
+function extractDiagnosticLine(
+	location: ParsedLineLocation | undefined,
+): number {
+	if (!location) return 0
+
+	const { span, sourceCode } = location
+
+	// Legacy/object form compatibility: { start: { line: N } }
+	if (
+		typeof span === 'object' &&
+		span !== null &&
+		'start' in span &&
+		typeof (span as { start?: unknown }).start === 'object' &&
+		(span as { start?: { line?: unknown } }).start !== null
+	) {
+		const line = (span as { start?: { line?: unknown } }).start?.line
+		if (typeof line === 'number' && Number.isFinite(line)) return line
+	}
+
+	// Biome JSON form: span is [startOffset, endOffset] (or a numeric start).
+	let startOffset: number | null = null
+	if (
+		Array.isArray(span) &&
+		span.length > 0 &&
+		typeof span[0] === 'number' &&
+		Number.isFinite(span[0])
+	) {
+		startOffset = span[0]
+	} else if (typeof span === 'number' && Number.isFinite(span)) {
+		startOffset = span
+	}
+
+	if (startOffset !== null && typeof sourceCode === 'string') {
+		const safeOffset = Math.max(0, Math.min(startOffset, sourceCode.length))
+		let line = 1
+		for (let i = 0; i < safeOffset; i += 1) {
+			if (sourceCode.charCodeAt(i) === 10) line += 1 // '\n'
+		}
+		return line
+	}
+
+	return 0
+}
+
 function parseBiomeOutput(stdout: string): BiomeDiagnostic[] {
 	const diagnostics: BiomeDiagnostic[] = []
 	try {
@@ -56,7 +105,7 @@ function parseBiomeOutput(stdout: string): BiomeDiagnostic[] {
 				if (d.severity === 'error' || d.severity === 'warning') {
 					diagnostics.push({
 						file: d.location?.path?.file || 'unknown',
-						line: d.location?.span?.start?.line || 0,
+						line: extractDiagnosticLine(d.location),
 						message: d.description || d.message || 'Unknown issue',
 						code: d.category || 'unknown',
 						severity: d.severity,

--- a/plugins/dx-biome-runner/hooks/biome-check.ts
+++ b/plugins/dx-biome-runner/hooks/biome-check.ts
@@ -1,0 +1,162 @@
+#!/usr/bin/env bun
+
+/**
+ * PostToolUse hook: Run Biome linting/formatting on edited files.
+ *
+ * Self-contained -- uses only Bun built-in APIs.
+ * Runs biome check with JSON reporter on edited files.
+ * Uses stdout JSON with `decision: "block"` for structured error feedback.
+ */
+
+import { resolve } from 'node:path'
+
+const BIOME_EXTENSIONS = [
+	'.ts',
+	'.tsx',
+	'.js',
+	'.jsx',
+	'.json',
+	'.jsonc',
+	'.css',
+]
+
+interface HookInput {
+	tool_name: string
+	tool_input?: {
+		file_path?: string
+		edits?: Array<{ file_path?: string }>
+	}
+}
+
+interface BiomeDiagnostic {
+	file: string
+	line: number
+	message: string
+	code: string
+	severity: 'error' | 'warning'
+}
+
+/** Extract unique file paths from hook input (Write, Edit, MultiEdit). */
+function extractFilePaths(input: HookInput): string[] {
+	const seen = new Set<string>()
+	if (input.tool_input?.file_path) seen.add(input.tool_input.file_path)
+	for (const edit of input.tool_input?.edits ?? []) {
+		if (edit.file_path) seen.add(edit.file_path)
+	}
+	return [...seen]
+}
+
+/** Parse Biome JSON reporter output into structured diagnostics. */
+function parseBiomeOutput(stdout: string): BiomeDiagnostic[] {
+	const diagnostics: BiomeDiagnostic[] = []
+	try {
+		const report = JSON.parse(stdout)
+		if (report.diagnostics) {
+			for (const d of report.diagnostics) {
+				if (d.severity === 'error' || d.severity === 'warning') {
+					diagnostics.push({
+						file: d.location?.path?.file || 'unknown',
+						line: d.location?.span?.start?.line || 0,
+						message: d.description || d.message || 'Unknown issue',
+						code: d.category || 'unknown',
+						severity: d.severity,
+					})
+				}
+			}
+		}
+	} catch {
+		// If parse fails, return empty -- biome may have crashed
+	}
+	return diagnostics
+}
+
+async function main() {
+	const input = await Bun.stdin.text()
+	let hookInput: HookInput
+	try {
+		hookInput = JSON.parse(input)
+	} catch {
+		process.exit(0)
+	}
+
+	const filePaths = extractFilePaths(hookInput).filter((f) =>
+		BIOME_EXTENSIONS.some((ext) => f.endsWith(ext)),
+	)
+
+	if (filePaths.length === 0) process.exit(0)
+
+	// Resolve to absolute paths for biome
+	const absolutePaths = filePaths.map((f) => resolve(f))
+
+	// Run biome check on specific files with JSON reporter
+	// '--' prevents argument injection via leading-dash file paths
+	const proc = Bun.spawn(
+		[
+			'bunx',
+			'@biomejs/biome',
+			'check',
+			'--reporter=json',
+			'--',
+			...absolutePaths,
+		],
+		{
+			stdout: 'pipe',
+			stderr: 'pipe',
+			env: { ...process.env, CI: 'true' },
+		},
+	)
+
+	const [exitCode, stdout, stderr] = await Promise.all([
+		proc.exited,
+		proc.stdout.text(),
+		proc.stderr.text(),
+	])
+
+	if (exitCode === 0) process.exit(0)
+
+	// Parse stdout first (biome --reporter=json writes JSON to stdout).
+	// Fall back to stderr only if stdout yields nothing -- avoids corrupting
+	// JSON parse when biome writes warnings/deprecations to stderr.
+	let diagnostics = parseBiomeOutput(stdout)
+	if (diagnostics.length === 0) {
+		diagnostics = parseBiomeOutput(stderr)
+	}
+
+	// Guard: biome crashed but produced no parseable diagnostics
+	if (diagnostics.length === 0) {
+		process.stderr.write(
+			`biome-check: biome exited ${exitCode} but no diagnostics parsed (possible crash). Check biome manually.\n`,
+		)
+		process.exit(0)
+	}
+
+	// Filter to only errors (not warnings) for blocking
+	const errors = diagnostics.filter((d) => d.severity === 'error')
+
+	if (errors.length > 0) {
+		const output = {
+			decision: 'block',
+			reason: `${errors.length} Biome error(s) in edited files`,
+			hookSpecificOutput: {
+				hookEventName: 'PostToolUse',
+				additionalContext: errors
+					.slice(0, 20)
+					.map((e) => `${e.file}:${e.line} [${e.code}] ${e.message}`)
+					.join('\n'),
+			},
+		}
+		process.stdout.write(JSON.stringify(output))
+		process.exit(0)
+	}
+
+	process.exit(0)
+}
+
+if (import.meta.main) {
+	const selfDestruct = setTimeout(() => {
+		process.stderr.write('biome-check: timed out\n')
+		process.exit(0) // Non-gating: allow through on timeout
+	}, 24_000)
+	selfDestruct.unref()
+	main()
+}

--- a/plugins/dx-biome-runner/hooks/biome-ci.ts
+++ b/plugins/dx-biome-runner/hooks/biome-ci.ts
@@ -1,0 +1,220 @@
+#!/usr/bin/env bun
+
+/**
+ * Stop hook: Run project-wide Biome linting/formatting at session end.
+ *
+ * Self-contained -- uses only Bun built-in APIs.
+ * Detects Bun workspace vs single package, runs appropriate command.
+ * Reports ALL diagnostics (errors and warnings).
+ * Exit 0 = clean, Exit 2 = errors (blocking).
+ */
+
+import { existsSync, readFileSync } from 'node:fs'
+
+const BIOME_EXTENSIONS = [
+	'.ts',
+	'.tsx',
+	'.js',
+	'.jsx',
+	'.json',
+	'.jsonc',
+	'.css',
+]
+
+interface BiomeDiagnostic {
+	file: string
+	line: number
+	message: string
+	code: string
+	severity: 'error' | 'warning'
+}
+
+async function getGitRoot(): Promise<string | null> {
+	const proc = Bun.spawn(['git', 'rev-parse', '--show-toplevel'], {
+		stdout: 'pipe',
+		stderr: 'pipe',
+	})
+	const [exitCode, stdout] = await Promise.all([
+		proc.exited,
+		proc.stdout.text(),
+		proc.stderr.text(),
+	])
+	if (exitCode !== 0) return null
+	return stdout.trim() || null
+}
+
+/** Check if any changed/staged/untracked files are Biome-relevant. */
+async function hasChangedBiomeFiles(): Promise<boolean> {
+	const commands = [
+		['git', 'diff', '--cached', '--name-only', '--diff-filter=d'],
+		['git', 'diff', '--name-only', '--diff-filter=d'],
+		['git', 'ls-files', '--others', '--exclude-standard'],
+	]
+	const outputs = await Promise.all(
+		commands.map(async (cmd) => {
+			const proc = Bun.spawn(cmd, { stdout: 'pipe', stderr: 'pipe' })
+			const [output] = await Promise.all([proc.stdout.text(), proc.exited])
+			return output
+		}),
+	)
+	return outputs.some((output) =>
+		output
+			.trim()
+			.split('\n')
+			.some(
+				(file) => file && BIOME_EXTENSIONS.some((ext) => file.endsWith(ext)),
+			),
+	)
+}
+
+/** Check if root is a Bun/npm workspace (array-form only). */
+function isWorkspace(root: string): boolean {
+	try {
+		const pkg = JSON.parse(readFileSync(`${root}/package.json`, 'utf-8')) as {
+			workspaces?: unknown
+		}
+		return Array.isArray(pkg.workspaces) && pkg.workspaces.length > 0
+	} catch {
+		return false
+	}
+}
+
+/** Parse Biome JSON reporter output into structured diagnostics. */
+function parseBiomeOutput(stdout: string): BiomeDiagnostic[] {
+	const diagnostics: BiomeDiagnostic[] = []
+	try {
+		const report = JSON.parse(stdout)
+		if (report.diagnostics) {
+			for (const d of report.diagnostics) {
+				if (d.severity === 'error' || d.severity === 'warning') {
+					diagnostics.push({
+						file: d.location?.path?.file || 'unknown',
+						line: d.location?.span?.start?.line || 0,
+						message: d.description || d.message || 'Unknown issue',
+						code: d.category || 'unknown',
+						severity: d.severity,
+					})
+				}
+			}
+		}
+	} catch {
+		// If parse fails, return empty
+	}
+	return diagnostics
+}
+
+async function main() {
+	// Check stop_hook_active to prevent infinite loops
+	let stopHookActive = false
+	try {
+		const raw = await Bun.stdin.text()
+		if (raw.trim()) {
+			const input = JSON.parse(raw) as { stop_hook_active?: boolean }
+			stopHookActive = input.stop_hook_active === true
+		}
+	} catch {
+		// stdin empty or not JSON -- proceed normally
+	}
+	if (stopHookActive) {
+		process.exit(0)
+	}
+
+	const root = await getGitRoot()
+	if (!root) process.exit(0)
+
+	if (!(await hasChangedBiomeFiles())) process.exit(0)
+
+	// Biome needs a biome.json config to run
+	if (!existsSync(`${root}/biome.json`) && !existsSync(`${root}/biome.jsonc`))
+		process.exit(0)
+
+	// For workspaces, use bun run check which is configured in package.json
+	// For single packages, run biome check directly with JSON reporter
+	const useWorkspaceScript = isWorkspace(root)
+	const cmd = useWorkspaceScript
+		? ['bun', 'run', '--filter', '*', 'check']
+		: ['bunx', '@biomejs/biome', 'check', '--reporter=json', root]
+
+	const proc = Bun.spawn(cmd, {
+		cwd: root,
+		stdout: 'pipe',
+		stderr: 'pipe',
+		env: { ...process.env, CI: 'true' },
+	})
+
+	const [exitCode, stdout, stderr] = await Promise.all([
+		proc.exited,
+		proc.stdout.text(),
+		proc.stderr.text(),
+	])
+
+	if (exitCode === 0) process.exit(0)
+
+	// For workspace script mode, output is not JSON -- report raw
+	if (useWorkspaceScript) {
+		const combinedOutput = `${stdout}${stderr}`.trim()
+		if (combinedOutput) {
+			process.stderr.write(
+				JSON.stringify({
+					tool: 'biome-ci',
+					status: 'error',
+					errorCount: 1,
+					errors: [
+						{
+							file: 'project',
+							line: 0,
+							message: combinedOutput.slice(0, 2000),
+						},
+					],
+				}),
+			)
+			process.exit(2)
+		}
+		process.exit(0)
+	}
+
+	// Parse stdout first (biome --reporter=json writes JSON to stdout).
+	// Fall back to stderr only if stdout yields nothing -- avoids corrupting
+	// JSON parse when biome writes warnings/deprecations to stderr.
+	let diagnostics = parseBiomeOutput(stdout)
+	if (diagnostics.length === 0) {
+		diagnostics = parseBiomeOutput(stderr)
+	}
+
+	// Guard: biome crashed but produced no parseable diagnostics
+	if (diagnostics.length === 0) {
+		process.stderr.write(
+			`biome-ci: biome exited ${exitCode} but no diagnostics parsed (possible crash). Check biome manually.\n`,
+		)
+		process.exit(0)
+	}
+
+	const errors = diagnostics.filter((d) => d.severity === 'error')
+
+	process.stderr.write(
+		JSON.stringify({
+			tool: 'biome-ci',
+			status: errors.length > 0 ? 'error' : 'warning',
+			errorCount: errors.length,
+			warningCount: diagnostics.length - errors.length,
+			errors: diagnostics.slice(0, 30).map((d) => ({
+				file: d.file,
+				line: d.line,
+				message: `[${d.code}] ${d.message}`,
+				severity: d.severity,
+			})),
+		}),
+	)
+
+	// Only block on errors, not warnings
+	process.exit(errors.length > 0 ? 2 : 0)
+}
+
+if (import.meta.main) {
+	const selfDestruct = setTimeout(() => {
+		process.stderr.write('biome-ci: timed out\n')
+		process.exit(0)
+	}, 96_000)
+	selfDestruct.unref()
+	main()
+}

--- a/plugins/dx-biome-runner/hooks/biome-ci.ts
+++ b/plugins/dx-biome-runner/hooks/biome-ci.ts
@@ -9,7 +9,7 @@
  * Exit 0 = clean, Exit 2 = errors (blocking).
  */
 
-import { existsSync, readFileSync } from 'node:fs'
+import { existsSync } from 'node:fs'
 
 const BIOME_EXTENSIONS = [
 	'.ts',
@@ -27,6 +27,11 @@ interface BiomeDiagnostic {
 	message: string
 	code: string
 	severity: 'error' | 'warning'
+}
+
+interface ParsedLineLocation {
+	span?: unknown
+	sourceCode?: string
 }
 
 async function getGitRoot(): Promise<string | null> {
@@ -67,19 +72,51 @@ async function hasChangedBiomeFiles(): Promise<boolean> {
 	)
 }
 
-/** Check if root is a Bun/npm workspace (array-form only). */
-function isWorkspace(root: string): boolean {
-	try {
-		const pkg = JSON.parse(readFileSync(`${root}/package.json`, 'utf-8')) as {
-			workspaces?: unknown
-		}
-		return Array.isArray(pkg.workspaces) && pkg.workspaces.length > 0
-	} catch {
-		return false
+/** Parse Biome JSON reporter output into structured diagnostics. */
+function extractDiagnosticLine(
+	location: ParsedLineLocation | undefined,
+): number {
+	if (!location) return 0
+
+	const { span, sourceCode } = location
+
+	// Legacy/object form compatibility: { start: { line: N } }
+	if (
+		typeof span === 'object' &&
+		span !== null &&
+		'start' in span &&
+		typeof (span as { start?: unknown }).start === 'object' &&
+		(span as { start?: { line?: unknown } }).start !== null
+	) {
+		const line = (span as { start?: { line?: unknown } }).start?.line
+		if (typeof line === 'number' && Number.isFinite(line)) return line
 	}
+
+	// Biome JSON form: span is [startOffset, endOffset] (or a numeric start).
+	let startOffset: number | null = null
+	if (
+		Array.isArray(span) &&
+		span.length > 0 &&
+		typeof span[0] === 'number' &&
+		Number.isFinite(span[0])
+	) {
+		startOffset = span[0]
+	} else if (typeof span === 'number' && Number.isFinite(span)) {
+		startOffset = span
+	}
+
+	if (startOffset !== null && typeof sourceCode === 'string') {
+		const safeOffset = Math.max(0, Math.min(startOffset, sourceCode.length))
+		let line = 1
+		for (let i = 0; i < safeOffset; i += 1) {
+			if (sourceCode.charCodeAt(i) === 10) line += 1 // '\n'
+		}
+		return line
+	}
+
+	return 0
 }
 
-/** Parse Biome JSON reporter output into structured diagnostics. */
 function parseBiomeOutput(stdout: string): BiomeDiagnostic[] {
 	const diagnostics: BiomeDiagnostic[] = []
 	try {
@@ -89,7 +126,7 @@ function parseBiomeOutput(stdout: string): BiomeDiagnostic[] {
 				if (d.severity === 'error' || d.severity === 'warning') {
 					diagnostics.push({
 						file: d.location?.path?.file || 'unknown',
-						line: d.location?.span?.start?.line || 0,
+						line: extractDiagnosticLine(d.location),
 						message: d.description || d.message || 'Unknown issue',
 						code: d.category || 'unknown',
 						severity: d.severity,
@@ -128,12 +165,8 @@ async function main() {
 	if (!existsSync(`${root}/biome.json`) && !existsSync(`${root}/biome.jsonc`))
 		process.exit(0)
 
-	// For workspaces, use bun run check which is configured in package.json
-	// For single packages, run biome check directly with JSON reporter
-	const useWorkspaceScript = isWorkspace(root)
-	const cmd = useWorkspaceScript
-		? ['bun', 'run', '--filter', '*', 'check']
-		: ['bunx', '@biomejs/biome', 'check', '--reporter=json', root]
+	// Always run Biome directly to avoid executing unrelated workspace scripts.
+	const cmd = ['bunx', '@biomejs/biome', 'check', '--reporter=json', root]
 
 	const proc = Bun.spawn(cmd, {
 		cwd: root,
@@ -149,29 +182,6 @@ async function main() {
 	])
 
 	if (exitCode === 0) process.exit(0)
-
-	// For workspace script mode, output is not JSON -- report raw
-	if (useWorkspaceScript) {
-		const combinedOutput = `${stdout}${stderr}`.trim()
-		if (combinedOutput) {
-			process.stderr.write(
-				JSON.stringify({
-					tool: 'biome-ci',
-					status: 'error',
-					errorCount: 1,
-					errors: [
-						{
-							file: 'project',
-							line: 0,
-							message: combinedOutput.slice(0, 2000),
-						},
-					],
-				}),
-			)
-			process.exit(2)
-		}
-		process.exit(0)
-	}
 
 	// Parse stdout first (biome --reporter=json writes JSON to stdout).
 	// Fall back to stderr only if stdout yields nothing -- avoids corrupting

--- a/plugins/dx-biome-runner/hooks/hooks.json
+++ b/plugins/dx-biome-runner/hooks/hooks.json
@@ -1,0 +1,29 @@
+{
+	"description": "Biome linter/formatter hooks: incremental post-edit check and full project check on stop",
+	"hooks": {
+		"PostToolUse": [
+			{
+				"matcher": "Write|Edit|MultiEdit",
+				"hooks": [
+					{
+						"type": "command",
+						"command": "bun run ${CLAUDE_PLUGIN_ROOT}/hooks/biome-check.ts",
+						"timeout": 30
+					}
+				]
+			}
+		],
+		"Stop": [
+			{
+				"matcher": "*",
+				"hooks": [
+					{
+						"type": "command",
+						"command": "bun run ${CLAUDE_PLUGIN_ROOT}/hooks/biome-ci.ts",
+						"timeout": 120
+					}
+				]
+			}
+		]
+	}
+}


### PR DESCRIPTION
## Summary

Ports the `dx-tsc-runner` pattern to Biome, wrapping the published `@side-quest/biome-runner` MCP server with hooks and a slash command.

- **MCP server**: 3 tools via `bunx @side-quest/biome-runner` -- `biome_lintCheck`, `biome_lintFix`, `biome_formatCheck`
- **PostToolUse hook** (`biome-check.ts`): runs `biome check` on edited files after Write/Edit/MultiEdit, blocks on errors only (warnings pass through)
- **Stop hook** (`biome-ci.ts`): full project check at session end, skips if no Biome-relevant files changed
- **Command**: `/dx-biome-runner:show-logs` for viewing MCP server logs
- **Marketplace**: version bumped 1.1.0 -> 1.2.0 (minor bump for new plugin)

## Security hardening (from code review)

- Added `--` end-of-options sentinel before file paths in spawn args to prevent argument injection via leading-dash filenames
- Parse `stdout` first for JSON diagnostics, fall back to `stderr` -- avoids corrupting JSON parse when Biome emits deprecation warnings to stderr alongside structured output

## Code review

5 agents run in parallel: `kieran-typescript-reviewer`, `code-simplicity-reviewer`, `security-sentinel`, `performance-oracle`, `agent-native-reviewer`. All P1/P2 findings addressed before merge.

Upstream findings filed: nathanvale/side-quest-runners#34 (add `biome_formatFix` tool + `--` sentinel in MCP server).

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: this is a local developer tooling plugin with no network or production runtime impact. All behavior is local process spawning (Biome, git).

---

[![Compound Engineered](https://img.shields.io/badge/Compound-Engineered-6366f1)](https://github.com/EveryInc/compound-engineering-plugin) 🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds dx-biome-runner plugin to enable Biome linting/formatting integration.
  * Adds incremental post-edit hooks for immediate lint/format checks and a session-end hook for full project checks.

* **Documentation**
  * Adds full plugin docs and a command guide for viewing runner logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->