### PR TITLE
feat(dx-bun-runner): add Bun test runner plugin to marketplace

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://code.claude.com/docs/en/plugin-marketplaces",
 	"name": "side-quest-marketplace",
-	"version": "1.2.0",
+	"version": "1.3.0",
 	"description": "Agent-native knowledge system with research, brainstorm, and knowledge capture skills",
 	"owner": {
 		"name": "Nathan Vale",
@@ -42,6 +42,13 @@
 			"description": "Biome linter and formatter MCP server with post-edit hooks for Claude Code",
 			"category": "development",
 			"tags": ["biome", "linting", "formatting", "hooks", "mcp"]
+		},
+		{
+			"name": "dx-bun-runner",
+			"source": "./plugins/dx-bun-runner",
+			"description": "Bun test runner MCP server with post-edit hooks for Claude Code",
+			"category": "development",
+			"tags": ["bun", "testing", "test-runner", "hooks", "mcp"]
 		},
 		{
 			"name": "kb-mpe",

--- a/plugins/dx-bun-runner/.claude-plugin/plugin.json
+++ b/plugins/dx-bun-runner/.claude-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+	"name": "dx-bun-runner",
+	"description": "Runs Bun tests after every edit to test files and at session end, surfacing failures inline",
+	"version": "1.0.0",
+	"author": { "name": "Nathan Vale" },
+	"repository": "https://github.com/nathanvale/side-quest-marketplace",
+	"keywords": ["bun", "testing", "test-runner", "diagnostics", "hooks"],
+	"license": "MIT",
+	"commands": ["./commands/show-logs.md"]
+}

--- a/plugins/dx-bun-runner/.mcp.json
+++ b/plugins/dx-bun-runner/.mcp.json
@@ -1,0 +1,8 @@
+{
+	"mcpServers": {
+		"bun-runner": {
+			"command": "bunx",
+			"args": ["--bun", "@side-quest/bun-runner"]
+		}
+	}
+}

--- a/plugins/dx-bun-runner/README.md
+++ b/plugins/dx-bun-runner/README.md
@@ -1,0 +1,54 @@
+# dx-bun-runner Plugin for Claude Code
+
+Bun test runner with post-edit hooks and an MCP server for on-demand test execution.
+
+## Components
+
+| Component | Mechanism | Trigger | Behavior |
+|-----------|-----------|---------|----------|
+| `bun_runTests` MCP tool | JSON-RPC over stdio | On-demand | Run all tests with structured JSON results |
+| `bun_testFile` MCP tool | JSON-RPC over stdio | On-demand | Run tests in a specific file |
+| `bun_testCoverage` MCP tool | JSON-RPC over stdio | On-demand | Run tests with coverage reporting |
+| PostToolUse hook | Shell script via bun | Write/Edit/MultiEdit | Blocks on failures in edited test files only |
+| Stop hook | Shell script via bun | Session end | Blocks on any project-wide test failures |
+
+## MCP Tools
+
+The MCP tools are provided by the `@side-quest/bun-runner` npm package. Use `response_format: "json"` for structured output:
+
+```typescript
+bun_runTests({ response_format: "json" })
+bun_testFile({ response_format: "json" })
+bun_testCoverage({ response_format: "json" })
+```
+
+## Hook Behavior
+
+**PostToolUse (bun-test.ts)**
+- Fires after every Write, Edit, or MultiEdit on source or test files
+- For test files (`.test.ts`, `.spec.ts`, etc.), runs them directly
+- For source files (`.ts`, `.tsx`, etc.), finds and runs the corresponding test file if it exists
+- Runs `bun test <file>` for each matched test file
+- Returns structured JSON with `decision: "block"` and failure details
+- 30s timeout, exits cleanly on timeout (non-blocking)
+
+**Stop (bun-test-ci.ts)**
+- Fires at session end
+- Runs `bun test` at git root (all tests)
+- Skips if no test files were changed
+- Checks `stop_hook_active` to prevent infinite loops
+- 120s timeout, exits cleanly on timeout (non-blocking)
+
+## Commands
+
+- `/dx-bun-runner:show-logs` -- View MCP server and hook logs from `~/.claude/logs/bun-runner.jsonl`
+
+## Prerequisites
+
+- [Bun](https://bun.sh/) runtime
+- Project with test files (`*.test.ts`, `*.spec.ts`, etc.)
+- `@side-quest/bun-runner` npm package (for MCP tools)
+
+## License
+
+MIT

--- a/plugins/dx-bun-runner/commands/show-logs.md
+++ b/plugins/dx-bun-runner/commands/show-logs.md
@@ -1,0 +1,18 @@
+---
+description: View bun-runner MCP server and hook logs
+model: haiku
+allowed-tools: Read
+argument-hint: "[count=N] [level=LEVEL] [errors] [cid=ID]"
+---
+
+Read the log file at `~/.claude/logs/bun-runner.jsonl` and display recent entries. $ARGUMENTS
+
+**Arguments:**
+- `count=N` -- Show last N entries (default: 20)
+- `level=LEVEL` -- Filter by log level (DEBUG, INFO, WARN, ERROR)
+- `errors` -- Shorthand for `level=ERROR`
+- `cid=ID` -- Filter by correlation ID
+
+**Format:** Each line is a JSON object with fields: `timestamp`, `level`, `message`, `cid`, and additional context fields.
+
+Display results in a compact table format showing timestamp, level, and message.

--- a/plugins/dx-bun-runner/hooks/bun-test-ci.ts
+++ b/plugins/dx-bun-runner/hooks/bun-test-ci.ts
@@ -1,0 +1,120 @@
+#!/usr/bin/env bun
+
+/**
+ * Stop hook: Run project-wide Bun tests at session end.
+ *
+ * Self-contained -- uses only Bun built-in APIs.
+ * Checks for changed source/test files, runs `bun test` at git root.
+ * Exit 0 = clean, Exit 2 = test failures (blocking).
+ */
+
+import { existsSync } from 'node:fs'
+
+const TS_EXTENSIONS = ['.ts', '.tsx', '.mts', '.cts']
+
+async function getGitRoot(): Promise<string | null> {
+	const proc = Bun.spawn(['git', 'rev-parse', '--show-toplevel'], {
+		stdout: 'pipe',
+		stderr: 'pipe',
+	})
+	const [exitCode, stdout] = await Promise.all([
+		proc.exited,
+		proc.stdout.text(),
+		proc.stderr.text(),
+	])
+	if (exitCode !== 0) return null
+	return stdout.trim() || null
+}
+
+/** Check if any changed/staged/untracked files are TypeScript (source or test). */
+async function hasChangedTsFiles(): Promise<boolean> {
+	const commands = [
+		['git', 'diff', '--cached', '--name-only', '--diff-filter=d'],
+		['git', 'diff', '--name-only', '--diff-filter=d'],
+		['git', 'ls-files', '--others', '--exclude-standard'],
+	]
+	const outputs = await Promise.all(
+		commands.map(async (cmd) => {
+			const proc = Bun.spawn(cmd, { stdout: 'pipe', stderr: 'pipe' })
+			const [output] = await Promise.all([proc.stdout.text(), proc.exited])
+			return output
+		}),
+	)
+	return outputs.some((output) =>
+		output
+			.trim()
+			.split('\n')
+			.some((file) => file && TS_EXTENSIONS.some((ext) => file.endsWith(ext))),
+	)
+}
+
+async function main() {
+	// Check stop_hook_active to prevent infinite loops
+	let stopHookActive = false
+	try {
+		const raw = await Bun.stdin.text()
+		if (raw.trim()) {
+			const input = JSON.parse(raw) as { stop_hook_active?: boolean }
+			stopHookActive = input.stop_hook_active === true
+		}
+	} catch {
+		// stdin empty or not JSON -- proceed normally
+	}
+	if (stopHookActive) {
+		process.exit(0)
+	}
+
+	const root = await getGitRoot()
+	if (!root) process.exit(0)
+
+	if (!(await hasChangedTsFiles())) process.exit(0)
+
+	// Need a package.json to run bun test
+	if (!existsSync(`${root}/package.json`)) process.exit(0)
+
+	const proc = Bun.spawn(['bun', 'test'], {
+		cwd: root,
+		stdout: 'pipe',
+		stderr: 'pipe',
+		env: { ...process.env, CI: 'true', NO_COLOR: '1' },
+	})
+
+	const [exitCode, stdout, stderr] = await Promise.all([
+		proc.exited,
+		proc.stdout.text(),
+		proc.stderr.text(),
+	])
+
+	if (exitCode === 0) process.exit(0)
+
+	// Bun test output goes to stderr
+	const output = stderr || stdout
+	const lines = output.split('\n').filter((l) => l.trim())
+
+	// Guard: bun crashed but produced no output
+	if (lines.length === 0) {
+		process.stderr.write(
+			`bun-test-ci: bun test exited ${exitCode} but no output (possible crash). Check tests manually.\n`,
+		)
+		process.exit(0)
+	}
+
+	process.stderr.write(
+		JSON.stringify({
+			tool: 'bun-test-ci',
+			status: 'error',
+			summary: `bun test exited with code ${exitCode}`,
+			errors: lines.slice(-30),
+		}),
+	)
+	process.exit(2)
+}
+
+if (import.meta.main) {
+	const selfDestruct = setTimeout(() => {
+		process.stderr.write('bun-test-ci: timed out\n')
+		process.exit(0)
+	}, 96_000)
+	selfDestruct.unref()
+	main().catch(() => process.exit(0))
+}

--- a/plugins/dx-bun-runner/hooks/bun-test.ts
+++ b/plugins/dx-bun-runner/hooks/bun-test.ts
@@ -1,0 +1,126 @@
+#!/usr/bin/env bun
+
+/**
+ * PostToolUse hook: Run Bun tests on edited test files.
+ *
+ * Self-contained -- uses only Bun built-in APIs.
+ * Matches test files directly, or finds corresponding test files for source files.
+ * Runs `bun test <file>` for each matched test file.
+ * Uses stdout JSON with `decision: "block"` to prompt Claude with failures.
+ */
+
+import { existsSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const TEST_SUFFIXES = ['.test.ts', '.test.tsx', '.spec.ts', '.spec.tsx']
+
+interface HookInput {
+	tool_name: string
+	tool_input?: {
+		file_path?: string
+		edits?: Array<{ file_path?: string }>
+	}
+}
+
+/** Extract unique file paths from hook input (Write, Edit, MultiEdit). */
+function extractFilePaths(input: HookInput): string[] {
+	const seen = new Set<string>()
+	if (input.tool_input?.file_path) seen.add(input.tool_input.file_path)
+	for (const edit of input.tool_input?.edits ?? []) {
+		if (edit.file_path) seen.add(edit.file_path)
+	}
+	return [...seen]
+}
+
+/** Find the test file for a given source or test file path. */
+function findTestFile(filePath: string): string | null {
+	// Already a test file
+	if (TEST_SUFFIXES.some((s) => filePath.endsWith(s))) {
+		return existsSync(filePath) ? filePath : null
+	}
+
+	// Try stripping extension and adding test suffixes
+	const base = filePath.replace(/\.(ts|tsx|js|jsx)$/, '')
+	if (base === filePath) return null // No recognized extension
+	for (const suffix of TEST_SUFFIXES) {
+		const testPath = `${base}${suffix}`
+		if (existsSync(testPath)) return testPath
+	}
+	return null
+}
+
+async function main() {
+	const input = await Bun.stdin.text()
+	let hookInput: HookInput
+	try {
+		hookInput = JSON.parse(input)
+	} catch {
+		process.exit(0)
+	}
+
+	const testFiles = [
+		...new Set(
+			extractFilePaths(hookInput)
+				.map((f) => findTestFile(resolve(f)))
+				.filter((f): f is string => f !== null),
+		),
+	]
+
+	if (testFiles.length === 0) process.exit(0)
+
+	// Hoist env to avoid copying process.env per spawn
+	const testEnv = { ...process.env, CI: 'true', NO_COLOR: '1' }
+
+	// Run bun test for each test file in parallel
+	const results = await Promise.all(
+		testFiles.map(async (testFile) => {
+			const proc = Bun.spawn(['bun', 'test', testFile], {
+				stdout: 'pipe',
+				stderr: 'pipe',
+				env: testEnv,
+			})
+			const [exitCode, stdout, stderr] = await Promise.all([
+				proc.exited,
+				proc.stdout.text(),
+				proc.stderr.text(),
+			])
+			return { testFile, exitCode, stdout, stderr }
+		}),
+	)
+
+	const failures = results.filter((r) => r.exitCode !== 0)
+
+	if (failures.length > 0) {
+		// Bun writes test output to stderr; send truncated raw output to Claude
+		const failureDetails = failures
+			.slice(0, 10)
+			.map((f) => {
+				const output = f.stderr || f.stdout
+				const lines = output.split('\n').filter((l) => l.trim())
+				return `${f.testFile}:\n${lines.slice(-20).join('\n')}`
+			})
+			.join('\n\n')
+
+		const output = {
+			decision: 'block',
+			reason: `${failures.length} test file(s) failed`,
+			hookSpecificOutput: {
+				hookEventName: 'PostToolUse',
+				additionalContext: failureDetails,
+			},
+		}
+		process.stdout.write(JSON.stringify(output))
+		process.exit(0)
+	}
+
+	process.exit(0)
+}
+
+if (import.meta.main) {
+	const selfDestruct = setTimeout(() => {
+		process.stderr.write('bun-test: timed out\n')
+		process.exit(0) // Non-gating: allow through on timeout
+	}, 24_000)
+	selfDestruct.unref()
+	main().catch(() => process.exit(0))
+}

--- a/plugins/dx-bun-runner/hooks/hooks.json
+++ b/plugins/dx-bun-runner/hooks/hooks.json
@@ -1,0 +1,29 @@
+{
+	"description": "Bun test hooks: incremental post-edit check for test files and full test run on stop",
+	"hooks": {
+		"PostToolUse": [
+			{
+				"matcher": "Write|Edit|MultiEdit",
+				"hooks": [
+					{
+						"type": "command",
+						"command": "bun run ${CLAUDE_PLUGIN_ROOT}/hooks/bun-test.ts",
+						"timeout": 30
+					}
+				]
+			}
+		],
+		"Stop": [
+			{
+				"matcher": "*",
+				"hooks": [
+					{
+						"type": "command",
+						"command": "bun run ${CLAUDE_PLUGIN_ROOT}/hooks/bun-test-ci.ts",
+						"timeout": 120
+					}
+				]
+			}
+		]
+	}
+}


### PR DESCRIPTION
## Summary

- Ports `bun-runner` to the marketplace as `dx-bun-runner`, following the upgrade patterns established by `dx-tsc-runner` and `dx-biome-runner`
- PostToolUse hook runs `bun test` on edited test files -- and finds corresponding test files when source files are edited (e.g. editing `utils.ts` triggers `utils.test.ts`)
- Stop hook runs full `bun test` at git root when any TypeScript files changed; blocks Claude from stopping on failures
- MCP server via `@side-quest/bun-runner` exposes 3 tools: `bun_runTests`, `bun_testFile`, `bun_testCoverage`
- Marketplace version bumped 1.2.0 -> 1.3.0

## Hook Patterns Applied

- Self-destruct timers (24s/96s at 80% of hook timeouts)
- `stop_hook_active` guard to prevent infinite loops
- `main().catch(() => process.exit(0))` to prevent unhandled rejection hangs
- `Bun.stdin.text() + JSON.parse()` consistent with sibling plugins
- Structured `{ tool, status, errors }` on stderr + exit 2 for Stop hook (aligned with tsc/biome)
- `NO_COLOR: '1'` env for clean output without ANSI escapes
- Hoisted env object outside spawn loop

## Test plan

- [ ] `bun run validate` passes (lint + typecheck + marketplace validation)
- [ ] PostToolUse hook triggers on `.test.ts` edits and runs that file
- [ ] PostToolUse hook triggers on `.ts` source edits and finds + runs corresponding test file
- [ ] PostToolUse hook exits cleanly (no block) when no test file exists for edited source
- [ ] Stop hook skips when no TypeScript files changed
- [ ] Stop hook blocks on test failures with structured stderr JSON
- [ ] Stop hook exits cleanly when `stop_hook_active: true`
- [ ] MCP server starts via `bunx --bun @side-quest/bun-runner`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added dx-bun-runner plugin for automated Bun test execution within Claude Code.
  * Tests run automatically after editing test files and at the end of your session.
  * Test failures surface inline for immediate visibility during development.

* **Chores**
  * Updated marketplace version to 1.3.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->